### PR TITLE
Add Buf Studio to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ or on [GitHub discussions](https://github.com/bufbuild/connect-web/discussions).
   Go implementation of gRPC, gRPC-Web, and Connect
 * [connect-demo](https://github.com/bufbuild/connect-demo):
   demonstration service powering demo.connect.build
+* [Buf Studio](https://studio.buf.build/): web UI for ad-hoc RPCs
 * [connect-crosstest](https://github.com/bufbuild/connect-crosstest):
   gRPC-Web and Connect interoperability tests
 


### PR DESCRIPTION
Adds a new entry in the "Ecosystem" section in the top-level README.md:

* [Buf Studio](https://studio.buf.build/): web UI for ad-hoc RPCs