### PR TITLE
Switch from deprecated TypeRegistry to createRegistry()

### DIFF
--- a/packages/connect-web-test/src/connect-error.spec.ts
+++ b/packages/connect-web-test/src/connect-error.spec.ts
@@ -22,10 +22,10 @@ import {
 } from "@bufbuild/connect-web";
 import {
   Any,
-  TypeRegistry,
   Struct,
   BoolValue,
   protoBase64,
+  createRegistry,
 } from "@bufbuild/protobuf";
 import { ErrorDetail } from "./gen/grpc/testing/messages_pb.js";
 
@@ -52,11 +52,11 @@ describe("connectErrorDetails()", () => {
   describe("on error without details", () => {
     const err = new ConnectError("foo");
     it("with empty TypeRegistry produces no details", () => {
-      const details = connectErrorDetails(err, TypeRegistry.from());
+      const details = connectErrorDetails(err, createRegistry());
       expect(details.length).toBe(0);
     });
     it("with non-empty TypeRegistry produces no details", () => {
-      const details = connectErrorDetails(err, TypeRegistry.from(ErrorDetail));
+      const details = connectErrorDetails(err, createRegistry(ErrorDetail));
       expect(details.length).toBe(0);
     });
     it("with MessageType produces no details", () => {
@@ -75,11 +75,11 @@ describe("connectErrorDetails()", () => {
       )
     );
     it("with empty TypeRegistry produces no details", () => {
-      const details = connectErrorDetails(err, TypeRegistry.from());
+      const details = connectErrorDetails(err, createRegistry());
       expect(details.length).toBe(0);
     });
     it("with non-empty TypeRegistry produces detail", () => {
-      const details = connectErrorDetails(err, TypeRegistry.from(ErrorDetail));
+      const details = connectErrorDetails(err, createRegistry(ErrorDetail));
       expect(details.length).toBe(1);
     });
     it("with MessageType produces detail", () => {

--- a/packages/connect-web/src/connect-error.ts
+++ b/packages/connect-web/src/connect-error.ts
@@ -16,13 +16,13 @@ import { Code, codeFromString, codeToString } from "./code.js";
 import {
   Any,
   AnyMessage,
+  createRegistry,
   IMessageTypeRegistry,
   JsonValue,
   Message,
   MessageType,
   proto3,
   protoBase64,
-  TypeRegistry,
 } from "@bufbuild/protobuf";
 
 /**
@@ -109,7 +109,7 @@ export function connectErrorDetails(
 ): AnyMessage[] {
   const typeRegistry =
     "typeName" in typeOrRegistry
-      ? TypeRegistry.from(typeOrRegistry, ...moreTypes)
+      ? createRegistry(typeOrRegistry, ...moreTypes)
       : typeOrRegistry;
   const details: AnyMessage[] = [];
   for (const data of error.details) {


### PR DESCRIPTION
https://github.com/bufbuild/protobuf-es/pull/183 removed the deprecated class TypeRegistry. This switches to the function createRegistry().

Users will be unaffected because the dependency on @bufbuild/protobuf is matched exactly (since it is a pre-release version).