### PR TITLE
Point to CommonJS in entrypoint

### DIFF
--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -18,10 +18,9 @@
   "types": "./dist/types/index.d.ts",
   "exports": {
     "import": "./dist/esm/index.js",
-    "require": "./dist/cjs/index.js",
-    "default": "./dist/esm/index.js"
+    "require": "./dist/cjs/index.js"
   },
-  "main": "./dist/esm/index.js",
+  "main": "./dist/cjs/index.js",
   "peerDependencies": {
     "@bufbuild/protobuf": "0.0.10"
   },


### PR DESCRIPTION
This points the `main` entrypoint in `package.json` to CommonJS instead of ESM in main entrypoint.

In addition, it removes the `default` conditional export.