### PR TITLE
Fixes type prop in conditional exports

### DIFF
--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -18,7 +18,8 @@
   "types": "./dist/types/index.d.ts",
   "exports": {
     "import": "./dist/esm/index.js",
-    "require": "./dist/cjs/index.js"
+    "require": "./dist/cjs/index.js",
+    "types": "./dist/types/index.d.ts"
   },
   "main": "./dist/cjs/index.js",
   "peerDependencies": {


### PR DESCRIPTION
Related to https://github.com/bufbuild/protobuf-es/pull/210.

When specifying conditional exports, the `types` prop must also be specified.  This is to add support for `NodeNext` module resolution when compiling with TypeScript.