### PR TITLE
Update to TypeScript 4.8.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "eslint": "^8.21.0",
         "eslint-plugin-node": "^11.1.0",
         "prettier": "^2.7.1",
-        "typescript": "~4.7.4"
+        "typescript": "~4.8.2"
       },
       "engines": {
         "node": ">=16",
@@ -3415,9 +3415,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
+      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -4013,7 +4013,7 @@
         "@bufbuild/protoc-gen-connect-web": "^0.2.0",
         "@bufbuild/protoc-gen-es": "^0.1.0",
         "esbuild": "^0.14.54",
-        "typescript": "^4.7.4"
+        "typescript": "^4.8.2"
       }
     },
     "packages/protoc-gen-connect-web": {
@@ -4243,7 +4243,7 @@
         "@bufbuild/protoc-gen-connect-web": "^0.2.0",
         "@bufbuild/protoc-gen-es": "^0.1.0",
         "esbuild": "^0.14.54",
-        "typescript": "^4.7.4"
+        "typescript": "^4.8.2"
       }
     },
     "@bufbuild/protobuf": {
@@ -6626,9 +6626,9 @@
       }
     },
     "typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
+      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
       "dev": true
     },
     "ua-parser-js": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "npm": ">=8"
   },
   "devDependencies": {
-    "typescript": "~4.7.4",
+    "typescript": "~4.8.2",
     "@typescript-eslint/eslint-plugin": "^5.36.1",
     "@typescript-eslint/parser": "^5.36.1",
     "eslint": "^8.21.0",

--- a/packages/connect-web-test/src/nodeonly/grpc-transport.ts
+++ b/packages/connect-web-test/src/nodeonly/grpc-transport.ts
@@ -260,7 +260,7 @@ export function createGrpcTransport(
               method,
               header,
               trailer,
-              async read(): Promise<ReadableStreamDefaultReadResult<O>> {
+              async read(): Promise<ReadableStreamReadResult<O>> {
                 const outcome = await new Promise<O | Error | null>(
                   (resolve) => {
                     if (callEnded) {

--- a/packages/connect-web/src/connect-transport.ts
+++ b/packages/connect-web/src/connect-transport.ts
@@ -271,7 +271,7 @@ export function createConnectTransport(
               method,
               header: response.headers,
               trailer: new Headers(),
-              async read(): Promise<ReadableStreamDefaultReadResult<O>> {
+              async read(): Promise<ReadableStreamReadResult<O>> {
                 const result = await reader.read();
                 if (result.done) {
                   if (!endStreamReceived) {

--- a/packages/connect-web/src/grpc-web-transport.ts
+++ b/packages/connect-web/src/grpc-web-transport.ts
@@ -256,7 +256,7 @@ export function createGrpcWebTransport(
               method,
               header: response.headers,
               trailer: new Headers(),
-              async read(): Promise<ReadableStreamDefaultReadResult<O>> {
+              async read(): Promise<ReadableStreamReadResult<O>> {
                 const result = await reader.read();
                 if (result.done) {
                   if (messageReceived && !endStreamReceived) {

--- a/packages/connect-web/src/interceptor.ts
+++ b/packages/connect-web/src/interceptor.ts
@@ -201,7 +201,7 @@ export interface StreamResponse<O extends Message<O> = AnyMessage> {
    * `{value: undefined, done: true}`.
    * 3. If an error occurred, the response is rejected with this error.
    */
-  read(): Promise<ReadableStreamDefaultReadResult<O>>;
+  read(): Promise<ReadableStreamReadResult<O>>;
 
   /**
    * Trailers received from the response.

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -15,6 +15,6 @@
     "@bufbuild/protoc-gen-connect-web": "^0.2.0",
     "@bufbuild/protoc-gen-es": "^0.1.0",
     "esbuild": "^0.14.54",
-    "typescript": "^4.7.4"
+    "typescript": "^4.8.2"
   }
 }


### PR DESCRIPTION
Updates TypeScript to v4.8.2.  In addition, this accommodates the breaking change in the type rename (`ReadableStreamDefaultReadResult` was renamed to `ReadableStreamReadResult`).