### PR TITLE
Updates to TypeScript 4.8.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "eslint": "^8.21.0",
         "eslint-plugin-node": "^11.1.0",
         "prettier": "^2.7.1",
-        "typescript": "~4.7.4"
+        "typescript": "~4.8.2"
       },
       "engines": {
         "node": ">=16",
@@ -3415,9 +3415,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
+      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -3665,7 +3665,7 @@
         "@bufbuild/protoc-gen-connect-web": "^0.2.0",
         "@bufbuild/protoc-gen-es": "^0.1.0",
         "esbuild": "^0.15.6",
-        "typescript": "^4.7.4"
+        "typescript": "^4.8.2"
       }
     },
     "packages/protoc-gen-connect-web": {
@@ -3745,7 +3745,7 @@
         "@bufbuild/protoc-gen-connect-web": "^0.2.0",
         "@bufbuild/protoc-gen-es": "^0.1.0",
         "esbuild": "^0.15.6",
-        "typescript": "^4.7.4"
+        "typescript": "^4.8.2"
       }
     },
     "@bufbuild/protobuf": {
@@ -6128,9 +6128,9 @@
       }
     },
     "typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
+      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
       "dev": true
     },
     "ua-parser-js": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "npm": ">=8"
   },
   "devDependencies": {
-    "typescript": "~4.7.4",
+    "typescript": "~4.8.2",
     "@typescript-eslint/eslint-plugin": "^5.36.1",
     "@typescript-eslint/parser": "^5.36.1",
     "eslint": "^8.21.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "npm": ">=8"
   },
   "devDependencies": {
-    "typescript": "~4.8.2",
+    "typescript": "^4.8.2",
     "@typescript-eslint/eslint-plugin": "^5.36.1",
     "@typescript-eslint/parser": "^5.36.1",
     "eslint": "^8.21.0",

--- a/packages/connect-web-test/src/nodeonly/grpc-transport.ts
+++ b/packages/connect-web-test/src/nodeonly/grpc-transport.ts
@@ -17,7 +17,7 @@ import type {
   StreamResponse,
   UnaryRequest,
   UnaryResponse,
-  ReadableStreamDefaultReadResult,
+  ReadableStreamDefaultReadResultLike,
 } from "@bufbuild/connect-web";
 import {
   Code,
@@ -261,7 +261,7 @@ export function createGrpcTransport(
               method,
               header,
               trailer,
-              async read(): Promise<ReadableStreamDefaultReadResult<O>> {
+              async read(): Promise<ReadableStreamDefaultReadResultLike<O>> {
                 const outcome = await new Promise<O | Error | null>(
                   (resolve) => {
                     if (callEnded) {

--- a/packages/connect-web-test/src/nodeonly/grpc-transport.ts
+++ b/packages/connect-web-test/src/nodeonly/grpc-transport.ts
@@ -260,11 +260,7 @@ export function createGrpcTransport(
               method,
               header,
               trailer,
-              // Note this is using the TypeScript type ReadableStreamReadResult and not the custom type used by
-              // Connect-Web.  This mimics how users will interact with the library (using their own DOM lib) and tests
-              // compatibility with the two types in that the Connect Web custom type should always be assignable to
-              // the type in the user's DOM lib.
-              async read(): Promise<ReadableStreamReadResult<O>> {
+              async read() {
                 const outcome = await new Promise<O | Error | null>(
                   (resolve) => {
                     if (callEnded) {

--- a/packages/connect-web-test/src/nodeonly/grpc-transport.ts
+++ b/packages/connect-web-test/src/nodeonly/grpc-transport.ts
@@ -17,7 +17,6 @@ import type {
   StreamResponse,
   UnaryRequest,
   UnaryResponse,
-  ReadableStreamDefaultReadResultLike,
 } from "@bufbuild/connect-web";
 import {
   Code,
@@ -261,7 +260,11 @@ export function createGrpcTransport(
               method,
               header,
               trailer,
-              async read(): Promise<ReadableStreamDefaultReadResultLike<O>> {
+              // Note this is using the TypeScript type ReadableStreamReadResult and not the custom type used by
+              // Connect-Web.  This mimics how users will interact with the library (using their own DOM lib) and tests
+              // compatibility with the two types in that the Connect Web custom type should always be assignable to
+              // the type in the user's DOM lib.
+              async read(): Promise<ReadableStreamReadResult<O>> {
                 const outcome = await new Promise<O | Error | null>(
                   (resolve) => {
                     if (callEnded) {

--- a/packages/connect-web-test/src/nodeonly/grpc-transport.ts
+++ b/packages/connect-web-test/src/nodeonly/grpc-transport.ts
@@ -17,6 +17,7 @@ import type {
   StreamResponse,
   UnaryRequest,
   UnaryResponse,
+  ReadableStreamDefaultReadResult,
 } from "@bufbuild/connect-web";
 import {
   Code,

--- a/packages/connect-web/src/connect-transport.ts
+++ b/packages/connect-web/src/connect-transport.ts
@@ -43,7 +43,7 @@ import { runServerStream, runUnary } from "./interceptor.js";
 import { createEnvelopeReadableStream, encodeEnvelopes } from "./envelope.js";
 import { mergeHeaders } from "./http-headers.js";
 import { assertFetchApi } from "./assert-fetch-api.js";
-import type { ReadableStreamDefaultReadResult } from "./lib.dom.streams.js";
+import type { ReadableStreamDefaultReadResultLike } from "./lib.dom.streams.js";
 
 /**
  * Options used to configure the Connect transport.
@@ -272,7 +272,7 @@ export function createConnectTransport(
               method,
               header: response.headers,
               trailer: new Headers(),
-              async read(): Promise<ReadableStreamDefaultReadResult<O>> {
+              async read(): Promise<ReadableStreamDefaultReadResultLike<O>> {
                 const result = await reader.read();
                 if (result.done) {
                   if (!endStreamReceived) {

--- a/packages/connect-web/src/connect-transport.ts
+++ b/packages/connect-web/src/connect-transport.ts
@@ -43,7 +43,7 @@ import { runServerStream, runUnary } from "./interceptor.js";
 import { createEnvelopeReadableStream, encodeEnvelopes } from "./envelope.js";
 import { mergeHeaders } from "./http-headers.js";
 import { assertFetchApi } from "./assert-fetch-api.js";
-import type { ReadableStreamDefaultReadResultLike } from "./lib.dom.streams.js";
+import type { ReadableStreamReadResultLike } from "./lib.dom.streams.js";
 
 /**
  * Options used to configure the Connect transport.
@@ -272,7 +272,7 @@ export function createConnectTransport(
               method,
               header: response.headers,
               trailer: new Headers(),
-              async read(): Promise<ReadableStreamDefaultReadResultLike<O>> {
+              async read(): Promise<ReadableStreamReadResultLike<O>> {
                 const result = await reader.read();
                 if (result.done) {
                   if (!endStreamReceived) {

--- a/packages/connect-web/src/connect-transport.ts
+++ b/packages/connect-web/src/connect-transport.ts
@@ -43,6 +43,7 @@ import { runServerStream, runUnary } from "./interceptor.js";
 import { createEnvelopeReadableStream, encodeEnvelopes } from "./envelope.js";
 import { mergeHeaders } from "./http-headers.js";
 import { assertFetchApi } from "./assert-fetch-api.js";
+import type { ReadableStreamDefaultReadResult } from "./lib.dom.streams.js";
 
 /**
  * Options used to configure the Connect transport.

--- a/packages/connect-web/src/grpc-web-transport.ts
+++ b/packages/connect-web/src/grpc-web-transport.ts
@@ -35,7 +35,7 @@ import {
 } from "./interceptor.js";
 import { createEnvelopeReadableStream, encodeEnvelopes } from "./envelope.js";
 import { assertFetchApi } from "./assert-fetch-api.js";
-import type { ReadableStreamDefaultReadResultLike } from "./lib.dom.streams.js";
+import type { ReadableStreamReadResultLike } from "./lib.dom.streams.js";
 
 /**
  * Options used to configure the gRPC-web transport.
@@ -257,7 +257,7 @@ export function createGrpcWebTransport(
               method,
               header: response.headers,
               trailer: new Headers(),
-              async read(): Promise<ReadableStreamDefaultReadResultLike<O>> {
+              async read(): Promise<ReadableStreamReadResultLike<O>> {
                 const result = await reader.read();
                 if (result.done) {
                   if (messageReceived && !endStreamReceived) {

--- a/packages/connect-web/src/grpc-web-transport.ts
+++ b/packages/connect-web/src/grpc-web-transport.ts
@@ -35,6 +35,7 @@ import {
 } from "./interceptor.js";
 import { createEnvelopeReadableStream, encodeEnvelopes } from "./envelope.js";
 import { assertFetchApi } from "./assert-fetch-api.js";
+import type { ReadableStreamDefaultReadResult } from "./lib.dom.streams.js";
 
 /**
  * Options used to configure the gRPC-web transport.

--- a/packages/connect-web/src/grpc-web-transport.ts
+++ b/packages/connect-web/src/grpc-web-transport.ts
@@ -35,7 +35,7 @@ import {
 } from "./interceptor.js";
 import { createEnvelopeReadableStream, encodeEnvelopes } from "./envelope.js";
 import { assertFetchApi } from "./assert-fetch-api.js";
-import type { ReadableStreamDefaultReadResult } from "./lib.dom.streams.js";
+import type { ReadableStreamDefaultReadResultLike } from "./lib.dom.streams.js";
 
 /**
  * Options used to configure the gRPC-web transport.
@@ -257,7 +257,7 @@ export function createGrpcWebTransport(
               method,
               header: response.headers,
               trailer: new Headers(),
-              async read(): Promise<ReadableStreamDefaultReadResult<O>> {
+              async read(): Promise<ReadableStreamDefaultReadResultLike<O>> {
                 const result = await reader.read();
                 if (result.done) {
                   if (messageReceived && !endStreamReceived) {

--- a/packages/connect-web/src/index.ts
+++ b/packages/connect-web/src/index.ts
@@ -51,5 +51,3 @@ export {
 } from "./http-headers.js";
 
 export { createEnvelopeReadableStream } from "./envelope.js";
-
-export { ReadableStreamDefaultReadResultLike } from "./lib.dom.streams.js";

--- a/packages/connect-web/src/index.ts
+++ b/packages/connect-web/src/index.ts
@@ -52,4 +52,4 @@ export {
 
 export { createEnvelopeReadableStream } from "./envelope.js";
 
-export { ReadableStreamDefaultReadResult } from "./lib.dom.streams.js";
+export { ReadableStreamDefaultReadResultLike } from "./lib.dom.streams.js";

--- a/packages/connect-web/src/index.ts
+++ b/packages/connect-web/src/index.ts
@@ -51,3 +51,5 @@ export {
 } from "./http-headers.js";
 
 export { createEnvelopeReadableStream } from "./envelope.js";
+
+export { ReadableStreamDefaultReadResult } from "./lib.dom.streams.js";

--- a/packages/connect-web/src/interceptor.ts
+++ b/packages/connect-web/src/interceptor.ts
@@ -21,6 +21,8 @@ import type {
   ServiceType,
 } from "@bufbuild/protobuf";
 
+import type { ReadableStreamDefaultReadResult } from "./lib.dom.streams.js";
+
 /**
  * An interceptor can add logic to clients, similar to the decorators
  * or middleware you may have seen in other libraries. Interceptors may

--- a/packages/connect-web/src/interceptor.ts
+++ b/packages/connect-web/src/interceptor.ts
@@ -21,7 +21,7 @@ import type {
   ServiceType,
 } from "@bufbuild/protobuf";
 
-import type { ReadableStreamDefaultReadResult } from "./lib.dom.streams.js";
+import type { ReadableStreamDefaultReadResultLike } from "./lib.dom.streams.js";
 
 /**
  * An interceptor can add logic to clients, similar to the decorators
@@ -203,7 +203,7 @@ export interface StreamResponse<O extends Message<O> = AnyMessage> {
    * `{value: undefined, done: true}`.
    * 3. If an error occurred, the response is rejected with this error.
    */
-  read(): Promise<ReadableStreamDefaultReadResult<O>>;
+  read(): Promise<ReadableStreamDefaultReadResultLike<O>>;
 
   /**
    * Trailers received from the response.

--- a/packages/connect-web/src/interceptor.ts
+++ b/packages/connect-web/src/interceptor.ts
@@ -21,7 +21,7 @@ import type {
   ServiceType,
 } from "@bufbuild/protobuf";
 
-import type { ReadableStreamDefaultReadResultLike } from "./lib.dom.streams.js";
+import type { ReadableStreamReadResultLike } from "./lib.dom.streams.js";
 
 /**
  * An interceptor can add logic to clients, similar to the decorators
@@ -203,7 +203,7 @@ export interface StreamResponse<O extends Message<O> = AnyMessage> {
    * `{value: undefined, done: true}`.
    * 3. If an error occurred, the response is rejected with this error.
    */
-  read(): Promise<ReadableStreamDefaultReadResultLike<O>>;
+  read(): Promise<ReadableStreamReadResultLike<O>>;
 
   /**
    * Trailers received from the response.

--- a/packages/connect-web/src/lib.dom.streams.ts
+++ b/packages/connect-web/src/lib.dom.streams.ts
@@ -1,0 +1,27 @@
+// Copyright 2021-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+interface ReadableStreamDefaultReadValueResult<T> {
+  done: false;
+  value: T;
+}
+
+interface ReadableStreamDefaultReadDoneResult {
+  done: true;
+  value?: undefined;
+}
+
+export type ReadableStreamDefaultReadResult<T> =
+  | ReadableStreamDefaultReadValueResult<T>
+  | ReadableStreamDefaultReadDoneResult;

--- a/packages/connect-web/src/lib.dom.streams.ts
+++ b/packages/connect-web/src/lib.dom.streams.ts
@@ -17,6 +17,9 @@
 // type is meant to mimic the type provided by TypeScript, just defined here so that we can have better control with
 // supporting various versions.  The suffix 'Like' has been added to the type name to differentiate it from the actual
 // type provided by TypeScript libs.
+export type ReadableStreamDefaultReadResultLike<T> =
+  | ReadableStreamDefaultReadValueResultLike<T>
+  | ReadableStreamDefaultReadDoneResultLike;
 
 interface ReadableStreamDefaultReadValueResultLike<T> {
   done: false;
@@ -27,7 +30,3 @@ interface ReadableStreamDefaultReadDoneResultLike {
   done: true;
   value?: undefined;
 }
-
-export type ReadableStreamDefaultReadResultLike<T> =
-  | ReadableStreamDefaultReadValueResultLike<T>
-  | ReadableStreamDefaultReadDoneResultLike;

--- a/packages/connect-web/src/lib.dom.streams.ts
+++ b/packages/connect-web/src/lib.dom.streams.ts
@@ -15,7 +15,8 @@
 // The name for the ReadableStreamDefaultReadResult type changed in TypeScript 4.8.2 to ReadableStreamReadResult.  This
 // makes supporting multiple versions of TypeScript difficult if we use the ambient type declaration.  Instead, this
 // type is meant to mimic the type provided by TypeScript, just defined here so that we can have better control with
-// supporting various versions.
+// supporting various versions.  The suffix 'Like' has been added to the type name to differentiate it from the actual
+// type provided by TypeScript libs.
 interface ReadableStreamDefaultReadValueResultLike<T> {
   done: false;
   value: T;

--- a/packages/connect-web/src/lib.dom.streams.ts
+++ b/packages/connect-web/src/lib.dom.streams.ts
@@ -17,6 +17,7 @@
 // type is meant to mimic the type provided by TypeScript, just defined here so that we can have better control with
 // supporting various versions.  The suffix 'Like' has been added to the type name to differentiate it from the actual
 // type provided by TypeScript libs.
+
 interface ReadableStreamDefaultReadValueResultLike<T> {
   done: false;
   value: T;

--- a/packages/connect-web/src/lib.dom.streams.ts
+++ b/packages/connect-web/src/lib.dom.streams.ts
@@ -12,11 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// The name for the ReadableStreamDefaultReadResult type changed in TypeScript 4.8.2 to ReadableStreamReadResult.  This
-// makes supporting multiple versions of TypeScript difficult if we use the ambient type declaration.  Instead, this
-// type is meant to mimic the type provided by TypeScript, just defined here so that we can have better control with
-// supporting various versions.  The suffix 'Like' has been added to the type name to differentiate it from the actual
-// type provided by TypeScript libs.
+// The name for the ReadableStreamDefaultReadResult type changed in TypeScript
+// 4.8.2 to ReadableStreamReadResult.  This makes supporting multiple versions
+// of TypeScript difficult if we use the ambient type declaration.  Instead,
+// this type is meant to mimic the type provided by TypeScript, just defined
+// here so that we can have better control with supporting various versions.
+// The suffix 'Like' has been added to the type name to differentiate it from
+// the actual type provided by TypeScript libs.
 export type ReadableStreamDefaultReadResultLike<T> =
   | ReadableStreamDefaultReadValueResultLike<T>
   | ReadableStreamDefaultReadDoneResultLike;

--- a/packages/connect-web/src/lib.dom.streams.ts
+++ b/packages/connect-web/src/lib.dom.streams.ts
@@ -12,16 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-interface ReadableStreamDefaultReadValueResult<T> {
+// The name for the ReadableStreamDefaultReadResult type changed in TypeScript 4.8.2 to ReadableStreamReadResult.  This
+// makes supporting multiple versions of TypeScript difficult if we use the ambient type declaration.  Instead, this
+// type is meant to mimic the type provided by TypeScript, just defined here so that we can have better control with
+// supporting various versions.
+interface ReadableStreamDefaultReadValueResultLike<T> {
   done: false;
   value: T;
 }
 
-interface ReadableStreamDefaultReadDoneResult {
+interface ReadableStreamDefaultReadDoneResultLike {
   done: true;
   value?: undefined;
 }
 
-export type ReadableStreamDefaultReadResult<T> =
-  | ReadableStreamDefaultReadValueResult<T>
-  | ReadableStreamDefaultReadDoneResult;
+export type ReadableStreamDefaultReadResultLike<T> =
+  | ReadableStreamDefaultReadValueResultLike<T>
+  | ReadableStreamDefaultReadDoneResultLike;

--- a/packages/connect-web/src/lib.dom.streams.ts
+++ b/packages/connect-web/src/lib.dom.streams.ts
@@ -19,16 +19,16 @@
 // here so that we can have better control with supporting various versions.
 // The suffix 'Like' has been added to the type name to differentiate it from
 // the actual type provided by TypeScript libs.
-export type ReadableStreamDefaultReadResultLike<T> =
-  | ReadableStreamDefaultReadValueResultLike<T>
-  | ReadableStreamDefaultReadDoneResultLike;
+export type ReadableStreamReadResultLike<T> =
+  | ReadableStreamReadValueResultLike<T>
+  | ReadableStreamReadDoneResultLike;
 
-interface ReadableStreamDefaultReadValueResultLike<T> {
+interface ReadableStreamReadValueResultLike<T> {
   done: false;
   value: T;
 }
 
-interface ReadableStreamDefaultReadDoneResultLike {
+interface ReadableStreamReadDoneResultLike {
   done: true;
   value?: undefined;
 }

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -15,6 +15,6 @@
     "@bufbuild/protoc-gen-connect-web": "^0.2.0",
     "@bufbuild/protoc-gen-es": "^0.1.0",
     "esbuild": "^0.15.6",
-    "typescript": "^4.7.4"
+    "typescript": "^4.8.2"
   }
 }


### PR DESCRIPTION
Update Connect Web to TypeScript 4.8.2 and in so doing, fix the breaking change on `ReadableStreamDefaultReadResult` naming.