### PR TITLE
Fix: raise a ConnectError with Code.Canceled from StreamResponse.read()

### DIFF
--- a/packages/connect-web-bench/README.md
+++ b/packages/connect-web-bench/README.md
@@ -10,5 +10,5 @@ it like a web server would usually do.
 
 | code generator | bundle size        | minified               | compressed           |
 |----------------|-------------------:|-----------------------:|---------------------:|
-| connect-web    | 87,571 b | 40,901 b | 11,335 b |
+| connect-web    | 87,712 b | 40,923 b | 11,344 b |
 | grpc-web       | 395,565 b    | 284,504 b    | 51,932 b |


### PR DESCRIPTION
Our goal is to only raise ConnectError. Due to on oversight, we do not convert an AbortError to a ConnectError in StreamResponse.read(). That means that a `for await` loop can raise an unwanted AbortError in some situations (response headers arrived, but the body is still being read).

This fixes the bug in the gRPC-web transport and in the Connect transport.

Thanks to @dnsco for the report!