### PR TITLE
Fix await res.json() in top-level README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ const res = await fetch("https://demo.connect.build/buf.connect.demo.eliza.v1.El
   headers: {"content-type": "application/json"},
   body: `{"sentence": "I feel happy."}`
 });
-const answer = res.json();
+const answer = await res.json();
 console.log(answer);
 // {sentence: 'When you feel happy, what do you do?'}
 ```


### PR DESCRIPTION
Without `await`, we receive a promise instead of an expected value