### PR TITLE
Deprecate ConnectError constructor

### DIFF
--- a/packages/connect-web-test/src/connect-error.spec.ts
+++ b/packages/connect-web-test/src/connect-error.spec.ts
@@ -22,10 +22,10 @@ import {
 } from "@bufbuild/connect-web";
 import {
   Any,
-  Struct,
   BoolValue,
-  protoBase64,
   createRegistry,
+  protoBase64,
+  Struct,
 } from "@bufbuild/protobuf";
 import { ErrorDetail } from "./gen/grpc/testing/messages_pb.js";
 
@@ -44,6 +44,17 @@ describe("ConnectError", () => {
       expect(e.message).toBe("[already_exists] foo");
       expect(e.rawMessage).toBe("foo");
       expect(String(e)).toBe("ConnectError: [already_exists] foo");
+    });
+    it("accepts details but ignores them in the deprecated constructor", () => {
+      const e = new ConnectError("foo", Code.AlreadyExists, [new Struct()], {
+        foo: "bar",
+      });
+      expect(e.details).toEqual([]);
+      expect(e.metadata.get("foo")).toBe("bar");
+    });
+    it("accepts metadata", () => {
+      const e = new ConnectError("foo", Code.AlreadyExists, { foo: "bar" });
+      expect(e.metadata.get("foo")).toBe("bar");
     });
   });
 });

--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -14,6 +14,7 @@
     "build:cjs": "npx tsc --project tsconfig.json --module commonjs --outDir ./dist/cjs && echo >./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
     "build:esm+types": "npx tsc --project tsconfig.json --module ES2015 --outDir ./dist/esm --declaration --declarationDir ./dist/types"
   },
+  "main": "./dist/cjs/index.js",
   "type": "module",
   "types": "./dist/types/index.d.ts",
   "exports": {
@@ -21,7 +22,6 @@
     "require": "./dist/cjs/index.js",
     "types": "./dist/types/index.d.ts"
   },
-  "main": "./dist/cjs/index.js",
   "peerDependencies": {
     "@bufbuild/protobuf": "0.1.1"
   },

--- a/packages/connect-web/src/connect-error.ts
+++ b/packages/connect-web/src/connect-error.ts
@@ -53,7 +53,7 @@ export class ConnectError extends Error {
    * When an error is parsed from the wire, error details are stored in
    * this property. They can be retrieved using connectErrorDetails().
    */
-  readonly details: Pick<Any, "typeUrl" | "value">[];
+  details: Pick<Any, "typeUrl" | "value">[];
 
   /**
    * The error message, but without a status code in front.
@@ -65,10 +65,26 @@ export class ConnectError extends Error {
 
   override name = "ConnectError";
 
+  /**
+   * Create a new ConnectError. If no code is provided, code "unknown" is
+   * used.
+   */
+  constructor(message: string, code?: Code, metadata?: HeadersInit);
+  /**
+   * @deprecated We do not support providing error details in the constructor.
+   * This signature was left here by accident, and will be removed in the next
+   * release.
+   */
+  constructor(
+    message: string,
+    code?: Code,
+    details?: AnyMessage[],
+    metadata?: HeadersInit
+  );
   constructor(
     message: string,
     code: Code = Code.Unknown,
-    details?: AnyMessage[],
+    detailsOrMetadata?: AnyMessage[] | HeadersInit,
     metadata?: HeadersInit
   ) {
     super(createMessage(message, code));
@@ -76,7 +92,12 @@ export class ConnectError extends Error {
     Object.setPrototypeOf(this, new.target.prototype);
     this.rawMessage = message;
     this.code = code;
-    this.metadata = new Headers(metadata ?? {});
+    // TODO once we remove the deprecated constructor, this can become `new Headers(metadata ?? {})`
+    const metadataInit =
+      metadata ??
+      (Array.isArray(detailsOrMetadata) ? undefined : detailsOrMetadata) ??
+      {};
+    this.metadata = new Headers(metadataInit);
     this.details = [];
   }
 }


### PR DESCRIPTION
Our ConnectError constructor takes an optional argument `details`, but never uses them. This wasn't cleaned up properly after https://github.com/bufbuild/connect-web/pull/164, where we changed the way we handle error details.

This introduces a new constructor signature:

```ts
constructor(message: string, code?: Code, metadata?: HeadersInit)
```

Details can still be added via the property. The old constructor is now deprecated:

```ts
/** @deprecated */
constructor(message: string, code?: Code, details?: AnyMessage[], metadata?: HeadersInit);
```

The next release will include the deprecation. The release after that will remove the old constructor.