### PR TITLE
updates `service` type to reflect only the necessary properties

### DIFF
--- a/packages/connect-web/src/connect-transport.ts
+++ b/packages/connect-web/src/connect-transport.ts
@@ -107,7 +107,7 @@ export function createConnectTransport(
       I extends Message<I> = AnyMessage,
       O extends Message<O> = AnyMessage
     >(
-      service: ServiceType,
+      service: Pick<ServiceType, 'typeName'>,
       method: MethodInfo<I, O>,
       signal: AbortSignal | undefined,
       timeoutMs: number | undefined,

--- a/packages/connect-web/src/grpc-web-transport.ts
+++ b/packages/connect-web/src/grpc-web-transport.ts
@@ -94,7 +94,7 @@ export function createGrpcWebTransport(
       I extends Message<I> = AnyMessage,
       O extends Message<O> = AnyMessage
     >(
-      service: ServiceType,
+      service: Pick<ServiceType, 'typeName'>,
       method: MethodInfo<I, O>,
       signal: AbortSignal | undefined,
       timeoutMs: number | undefined,

--- a/packages/connect-web/src/interceptor.ts
+++ b/packages/connect-web/src/interceptor.ts
@@ -95,7 +95,7 @@ export interface UnaryRequest<I extends Message<I> = AnyMessage> {
   /**
    * Metadata related to the service that is being called.
    */
-  readonly service: ServiceType;
+  readonly service: Pick<ServiceType, 'typeName'>;
 
   /**
    * Metadata related to the service method that is being called.
@@ -142,7 +142,7 @@ export interface UnaryResponse<O extends Message<O> = AnyMessage> {
   /**
    * Metadata related to the service that is being called.
    */
-  readonly service: ServiceType;
+  readonly service: Pick<ServiceType, 'typeName'>;
 
   /**
    * Metadata related to the service method that is being called.

--- a/packages/connect-web/src/transport.ts
+++ b/packages/connect-web/src/transport.ts
@@ -32,7 +32,7 @@ export interface Transport {
    * responds with a single output message.
    */
   unary<I extends Message<I> = AnyMessage, O extends Message<O> = AnyMessage>(
-    service: ServiceType,
+    service: Pick<ServiceType, 'typeName'>,
     method: MethodInfo<I, O>,
     signal: AbortSignal | undefined,
     timeoutMs: number | undefined,
@@ -48,7 +48,7 @@ export interface Transport {
     I extends Message<I> = AnyMessage,
     O extends Message<O> = AnyMessage
   >(
-    service: ServiceType,
+    service: Pick<ServiceType, 'typeName'>,
     method: MethodInfo<I, O>,
     signal: AbortSignal | undefined,
     timeoutMs: number | undefined,


### PR DESCRIPTION
I hit a use case in generating a plugin that requires connect-web for transport but doesn't need the generation of services.  In that situation, this was the only blocker I am aware of that forced me to use a service.  Come to find out, then, that the full service isn't actually required.  This PR addresses that by only asking for the required fields.  It's a backwards compatible change because a full service will still structurally match. 