### PR TITLE
Fixup createMethodUrl()

### DIFF
--- a/packages/connect-core/src/create-method-url.spec.ts
+++ b/packages/connect-core/src/create-method-url.spec.ts
@@ -1,0 +1,44 @@
+import { createMethodUrl } from "./create-method-url.js";
+
+describe("createMethodUrl()", function () {
+  it("should create the expected URL", function () {
+    const url = createMethodUrl(
+      "https://example.com",
+      "example.Service",
+      "Method"
+    );
+    expect(url.toString()).toEqual(
+      "https://example.com/example.Service/Method"
+    );
+  });
+  it("should not duplicating slashes", function () {
+    const url = createMethodUrl(
+      "https://example.com/",
+      "example.Service",
+      "Method"
+    );
+    expect(url.toString()).toEqual(
+      "https://example.com/example.Service/Method"
+    );
+  });
+  it("should merge paths", function () {
+    const url = createMethodUrl(
+      "https://example.com/twirp",
+      "example.Service",
+      "Method"
+    );
+    expect(url.toString()).toEqual(
+      "https://example.com/twirp/example.Service/Method"
+    );
+  });
+  it("should merge paths without duplicating slashes", function () {
+    const url = createMethodUrl(
+      "https://example.com/twirp/",
+      "example.Service",
+      "Method"
+    );
+    expect(url.toString()).toEqual(
+      "https://example.com/twirp/example.Service/Method"
+    );
+  });
+});

--- a/packages/connect-core/src/create-method-url.ts
+++ b/packages/connect-core/src/create-method-url.ts
@@ -1,9 +1,9 @@
 import type { MethodInfo, ServiceType } from "@bufbuild/protobuf";
 
 /**
- * Create a URL for the given RPC. This simply joins the qualified
- * service name with the method name, separated by a slash. This format
- * is used by the protocols Connect, gRPC and Twirp.
+ * Create a URL for the given RPC. This simply adds the qualified
+ * service name, a slash, and the method name to the path.
+ * This format is used by the protocols Connect, gRPC and Twirp.
  */
 export function createMethodUrl(
   baseUrl: string | URL,
@@ -12,5 +12,5 @@ export function createMethodUrl(
 ): URL {
   const s = typeof service == "string" ? service : service.typeName;
   const m = typeof method == "string" ? method : method.name;
-  return new URL(`${s}/${m}`, baseUrl);
+  return new URL(baseUrl.toString().replace(/\/?$/, `/${s}/${m}`));
 }

--- a/packages/connect-core/src/index.ts
+++ b/packages/connect-core/src/index.ts
@@ -49,7 +49,10 @@ export {
   encodeEnvelopes,
 } from "./envelope.js";
 export { connectErrorFromJson } from "./connect-error-from-json.js";
-export { connectExpectContentType } from "./connect-expect-content-type.js";
+export {
+  connectExpectContentType,
+  connectParseContentType,
+} from "./connect-expect-content-type.js";
 export { connectCreateRequestHeader } from "./connect-create-request-header.js";
 export {
   connectEndStreamFromJson,
@@ -59,7 +62,10 @@ export { connectCodeFromHttpStatus } from "./connect-code-from-http-status.js";
 export { connectTrailerDemux } from "./connect-trailer-demux.js";
 export { grpcWebCodeFromHttpStatus } from "./grpcweb-code-from-http-status.js";
 export { grpcWebCreateRequestHeader } from "./grpc-web-create-request-header.js";
-export { grpcWebExpectContentType } from "./grpc-web-expect-content-type.js";
+export {
+  grpcWebExpectContentType,
+  grpcWebParseContentType,
+} from "./grpc-web-expect-content-type.js";
 export {
   grpcWebTrailerParse,
   grpcWebTrailerSerialize,


### PR DESCRIPTION
The function did not handle base URLs with a path correctly.  
This adds tests, and exports more functions from @bufbuild/connect-core.