### PR TITLE
Support the construction of errors with details

### DIFF
--- a/packages/connect-core/src/connect-code-to-http-status.ts
+++ b/packages/connect-core/src/connect-code-to-http-status.ts
@@ -1,0 +1,44 @@
+import { Code } from "./code.js";
+
+/**
+ * Returns a HTTP status code for the given Connect code.
+ * See https://connect.build/docs/protocol#error-codes
+ */
+export function connectCodeToHttpStatus(code: Code): number {
+  switch (code) {
+    case Code.Canceled:
+      return 408; // Request Timeout
+    case Code.Unknown:
+      return 500; // Internal Server Error
+    case Code.InvalidArgument:
+      return 400; // Bad Request
+    case Code.DeadlineExceeded:
+      return 408; // Request Timeout
+    case Code.NotFound:
+      return 404; // Not Found
+    case Code.AlreadyExists:
+      return 409; // Conflict
+    case Code.PermissionDenied:
+      return 403; // Forbidden
+    case Code.ResourceExhausted:
+      return 429; // Too Many Requests
+    case Code.FailedPrecondition:
+      return 412; // Precondition Failed
+    case Code.Aborted:
+      return 409; // Conflict
+    case Code.OutOfRange:
+      return 400; // Bad Request
+    case Code.Unimplemented:
+      return 404; // Not Found
+    case Code.Internal:
+      return 500; // Internal Server Error
+    case Code.Unavailable:
+      return 503; // Service Unavailable
+    case Code.DataLoss:
+      return 500; // Internal Server Error
+    case Code.Unauthenticated:
+      return 401; // Unauthorized
+    default:
+      return 500; // same as CodeUnknown
+  }
+}

--- a/packages/connect-core/src/connect-error-from-json.spec.ts
+++ b/packages/connect-core/src/connect-error-from-json.spec.ts
@@ -91,9 +91,6 @@ describe("connectErrorFromJson()", () => {
     it("adds to raw detail", () => {
       const error = connectErrorFromJson(json);
       expect(error.details.length).toBe(1);
-      expect(error.details[0]?.typeUrl).toBe(
-        "type.googleapis.com/handwritten.ErrorDetail"
-      );
     });
     it("works with connectErrorDetails()", () => {
       const error = connectErrorFromJson(json);

--- a/packages/connect-core/src/connect-error-from-json.ts
+++ b/packages/connect-core/src/connect-error-from-json.ts
@@ -42,7 +42,7 @@ export function connectErrorFromJson(
   if (message != null && typeof message !== "string") {
     throw newParseError(jsonValue.code, ".message");
   }
-  const error = new ConnectError(message ?? "", code, undefined, metadata);
+  const error = new ConnectError(message ?? "", code, metadata);
   if ("details" in jsonValue && Array.isArray(jsonValue.details)) {
     for (const detail of jsonValue.details) {
       if (
@@ -50,14 +50,16 @@ export function connectErrorFromJson(
         typeof detail != "object" ||
         Array.isArray(detail) ||
         typeof detail.type != "string" ||
-        typeof detail.value != "string"
+        typeof detail.value != "string" ||
+        ("debug" in detail && typeof detail.debug != "object")
       ) {
         throw newParseError(detail, `.details`);
       }
       try {
         error.details.push({
-          typeUrl: "type.googleapis.com/" + detail.type,
+          type: detail.type,
           value: protoBase64.dec(detail.value),
+          debug: detail.debug,
         });
       } catch (e) {
         throw newParseError(e, `.details`, false);

--- a/packages/connect-core/src/connect-error-to-json.spec.ts
+++ b/packages/connect-core/src/connect-error-to-json.spec.ts
@@ -1,0 +1,59 @@
+import { ConnectError } from "./connect-error.js";
+import { Code } from "./code.js";
+import { connectErrorToJson } from "./connect-error-to-json.js";
+import { Message, proto3, protoBase64, ScalarType } from "@bufbuild/protobuf";
+
+describe("connectErrorToJson()", () => {
+  it("serializes code and message", () => {
+    const json = connectErrorToJson(
+      new ConnectError("Not permitted", Code.PermissionDenied)
+    );
+    expect(json.code as unknown).toBe("permission_denied");
+    expect(json.message as unknown).toBe("Not permitted");
+  });
+  it("does not serialize empty message", () => {
+    const json = connectErrorToJson(
+      new ConnectError("", Code.PermissionDenied)
+    );
+    expect(json.code as unknown).toBe("permission_denied");
+    expect(json.message as unknown).toBeUndefined();
+  });
+  it("serializes details", () => {
+    type ErrorDetail = Message<ErrorDetail> & {
+      reason: string;
+      domain: string;
+    };
+    const ErrorDetail = proto3.makeMessageType<ErrorDetail>(
+      "handwritten.ErrorDetail",
+      [
+        { no: 1, name: "reason", kind: "scalar", T: ScalarType.STRING },
+        { no: 2, name: "domain", kind: "scalar", T: ScalarType.STRING },
+      ]
+    );
+    const err = new ConnectError("Not permitted", Code.PermissionDenied);
+    err.details.push(
+      new ErrorDetail({ reason: "soirée 🎉", domain: "example.com" })
+    );
+    const got = connectErrorToJson(err);
+    const want = {
+      code: "permission_denied",
+      message: "Not permitted",
+      details: [
+        {
+          type: ErrorDetail.typeName,
+          value: protoBase64.enc(
+            new ErrorDetail({
+              reason: "soirée 🎉",
+              domain: "example.com",
+            }).toBinary()
+          ),
+          debug: {
+            reason: "soirée 🎉",
+            domain: "example.com",
+          },
+        },
+      ],
+    };
+    expect(got).toEqual(want);
+  });
+});

--- a/packages/connect-core/src/connect-error-to-json.ts
+++ b/packages/connect-core/src/connect-error-to-json.ts
@@ -1,0 +1,62 @@
+import {
+  JsonObject,
+  JsonValue,
+  JsonWriteOptions,
+  Message,
+  protoBase64,
+} from "@bufbuild/protobuf";
+import type { ConnectError } from "./connect-error.js";
+import { codeToString } from "./code.js";
+
+/**
+ * Serialize the given error to JSON.
+ *
+ * The JSON serialization options are required to produce the optional
+ * human-readable representation in the "debug" key if the detail uses
+ * google.protobuf.Any. If serialization of the "debug" value fails, it
+ * is silently disregarded.
+ *
+ * See https://connect.build/docs/protocol#error-end-stream
+ */
+export function connectErrorToJson(
+  error: ConnectError,
+  jsonWriteOptions?: Partial<JsonWriteOptions>
+): JsonObject {
+  const o: JsonObject = {
+    code: codeToString(error.code),
+  };
+  if (error.rawMessage.length > 0) {
+    o.message = error.rawMessage;
+  }
+  if (error.details.length > 0) {
+    type IncomingDetail = {
+      type: string;
+      value: Uint8Array;
+      debug?: JsonValue;
+    };
+    o.details = error.details
+      .map((value) => {
+        if (value instanceof Message) {
+          const i: IncomingDetail = {
+            type: value.getType().typeName,
+            value: value.toBinary(),
+          };
+          try {
+            i.debug = value.toJson(jsonWriteOptions);
+          } catch (e) {
+            // We deliberately ignore errors that may occur when serializing
+            // a message to JSON (the message contains an Any).
+            // The rationale is that we are only trying to provide optional
+            // debug information.
+          }
+          return i;
+        }
+        return value;
+      })
+      .map(({ value, ...rest }) => ({
+        ...rest,
+        value: protoBase64.enc(value),
+      }));
+  }
+  return o;
+}

--- a/packages/connect-core/src/connect-error.spec.ts
+++ b/packages/connect-core/src/connect-error.spec.ts
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import {
-  Any,
   BoolValue,
   createRegistry,
   Message,
@@ -49,13 +48,6 @@ describe("ConnectError", () => {
       expect(e.message).toBe("[already_exists] foo");
       expect(e.rawMessage).toBe("foo");
       expect(String(e)).toBe("ConnectError: [already_exists] foo");
-    });
-    it("accepts details but ignores them in the deprecated constructor", () => {
-      const e = new ConnectError("foo", Code.AlreadyExists, [new Struct()], {
-        foo: "bar",
-      });
-      expect(e.details).toEqual([]);
-      expect(e.metadata.get("foo")).toBe("bar");
     });
     it("accepts metadata", () => {
       const e = new ConnectError("foo", Code.AlreadyExists, { foo: "bar" });
@@ -94,12 +86,10 @@ describe("connectErrorDetails()", () => {
   describe("on error with Any details", () => {
     const err = new ConnectError("foo");
     err.details.push(
-      Any.pack(
-        new ErrorDetail({
-          reason: "soirée 🎉",
-          domain: "example.com",
-        })
-      )
+      new ErrorDetail({
+        reason: "soirée 🎉",
+        domain: "example.com",
+      })
     );
     it("with empty TypeRegistry produces no details", () => {
       const details = connectErrorDetails(err, createRegistry());

--- a/packages/connect-core/src/connect-error.ts
+++ b/packages/connect-core/src/connect-error.ts
@@ -18,6 +18,7 @@ import {
   AnyMessage,
   createRegistry,
   IMessageTypeRegistry,
+  JsonValue,
   Message,
   MessageType,
 } from "@bufbuild/protobuf";
@@ -47,10 +48,13 @@ export class ConnectError extends Error {
   readonly metadata: Headers;
 
   /**
-   * When an error is parsed from the wire, error details are stored in
-   * this property. They can be retrieved using connectErrorDetails().
+   * When an error is parsed from the wire, incoming error details are stored
+   * in this property. They can be retrieved using connectErrorDetails().
+   *
+   * When an error is constructed to be sent over the wire, outgoing error
+   * details are stored in this property as well.
    */
-  details: Pick<Any, "typeUrl" | "value">[];
+  details: (Message | IncomingDetail)[];
 
   /**
    * The error message, but without a status code in front.
@@ -63,41 +67,34 @@ export class ConnectError extends Error {
   override name = "ConnectError";
 
   /**
-   * Create a new ConnectError. If no code is provided, code "unknown" is
-   * used.
+   * Create a new ConnectError.
+   * If no code is provided, code "unknown" is used.
+   * Outgoing details are only relevant for the server side - a service may
+   * raise an error with details, and it is up to the protocol implementation
+   * to encode and send the details along with error.
    */
-  constructor(message: string, code?: Code, metadata?: HeadersInit);
-  /**
-   * @deprecated We do not support providing error details in the constructor.
-   * This signature was left here by accident, and will be removed in the next
-   * release.
-   */
-  constructor(
-    message: string,
-    code?: Code,
-    details?: AnyMessage[],
-    metadata?: HeadersInit
-  );
   constructor(
     message: string,
     code: Code = Code.Unknown,
-    detailsOrMetadata?: AnyMessage[] | HeadersInit,
-    metadata?: HeadersInit
+    metadata?: HeadersInit,
+    outgoingDetails?: Message[]
   ) {
     super(createMessage(message, code));
     // see https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-2.html#example
     Object.setPrototypeOf(this, new.target.prototype);
     this.rawMessage = message;
     this.code = code;
-    // TODO once we remove the deprecated constructor, this can become `new Headers(metadata ?? {})`
-    const metadataInit =
-      metadata ??
-      (Array.isArray(detailsOrMetadata) ? undefined : detailsOrMetadata) ??
-      {};
-    this.metadata = new Headers(metadataInit);
-    this.details = [];
+    this.metadata = new Headers(metadata ?? {});
+    this.details = outgoingDetails ?? [];
   }
 }
+
+/**
+ * An incoming detail is basically a google.protobuf.Any, but it includes an
+ * optional JSON representation in the "debug" key, and stores a type name
+ * instead of a type URL.
+ */
+type IncomingDetail = { type: string; value: Uint8Array; debug?: JsonValue };
 
 /**
  * Retrieve error details from a ConnectError. On the wire, error details are
@@ -125,17 +122,25 @@ export function connectErrorDetails(
   typeOrRegistry: MessageType | IMessageTypeRegistry,
   ...moreTypes: MessageType[]
 ): AnyMessage[] {
-  const typeRegistry =
-    "typeName" in typeOrRegistry
-      ? createRegistry(typeOrRegistry, ...moreTypes)
-      : typeOrRegistry;
+  const types: MessageType[] =
+    "typeName" in typeOrRegistry ? [typeOrRegistry, ...moreTypes] : [];
+  const registry =
+    "typeName" in typeOrRegistry ? createRegistry(...types) : typeOrRegistry;
   const details: AnyMessage[] = [];
   for (const data of error.details) {
+    if (data instanceof Message) {
+      if (registry.findMessage(data.getType().typeName)) {
+        details.push(data);
+      }
+      continue;
+    }
     try {
-      const any = new Any(data);
-      const name = any.typeUrl.substring(any.typeUrl.lastIndexOf("/") + 1);
-      const type = typeRegistry.findMessage(name);
+      const type = registry.findMessage(data.type);
       if (type) {
+        const any = new Any({
+          typeUrl: `type.googleapis.com/${data.type}`,
+          value: data.value,
+        });
         const message = new type();
         if (any.unpackTo(message)) {
           details.push(message);

--- a/packages/connect-core/src/index.ts
+++ b/packages/connect-core/src/index.ts
@@ -49,6 +49,7 @@ export {
   encodeEnvelopes,
 } from "./envelope.js";
 export { connectErrorFromJson } from "./connect-error-from-json.js";
+export { connectErrorToJson } from "./connect-error-to-json.js";
 export {
   connectExpectContentType,
   connectParseContentType,
@@ -59,6 +60,7 @@ export {
   connectEndStreamFlag,
 } from "./connect-end-stream.js";
 export { connectCodeFromHttpStatus } from "./connect-code-from-http-status.js";
+export { connectCodeToHttpStatus } from "./connect-code-to-http-status.js";
 export { connectTrailerDemux } from "./connect-trailer-demux.js";
 export { grpcWebCodeFromHttpStatus } from "./grpcweb-code-from-http-status.js";
 export { grpcWebCreateRequestHeader } from "./grpc-web-create-request-header.js";

--- a/packages/connect-web-next/src/grpc-web-transport.ts
+++ b/packages/connect-web-next/src/grpc-web-transport.ts
@@ -362,7 +362,10 @@ function validateGrpcStatus(headerOrTrailer: Headers) {
       status.code,
       headerOrTrailer
     );
-    error.details.push(...status.details);
+    error.details = status.details.map((any) => ({
+      type: any.typeUrl.substring(any.typeUrl.lastIndexOf("/") + 1),
+      value: any.value,
+    }));
     throw error;
   }
   const grpcStatus = headerOrTrailer.get("grpc-status");


### PR DESCRIPTION
We want to enable service implementations to raise an error with details. This changes the `details` property of `ConnectError` to hold both incoming _and_ outgoing error details, which need to be represented in slightly different forms.

This is technically a breaking change because the property is public, but we always recommended to use the connectErrorDetails() to obtain details from an error. User-provided transport implementations that parse error details will need to update.

This re-introduces the `details` argument to the ConnectError constructor that was removed in #164 and deprecated in #272. Because we change the order of arguments, the new constructor signature is compatible with the deprecation.

This also adds the functions connectCodeToHttpStatus() and connectErrorToJson().