### PR TITLE
Handle invalid input for unary and server streaming methods

### DIFF
--- a/packages/connect-node/src/connect-protocol.ts
+++ b/packages/connect-node/src/connect-protocol.ts
@@ -108,9 +108,9 @@ export function createConnectProtocol(
                 type.binary
               );
 
-            const input = parse(await readToEnd(req));
             let output: O | PartialMessage<O>;
             try {
+              const input = parse(await readToEnd(req));
               output = await spec.impl(input, context);
             } catch (e) {
               return await endWithConnectUnaryError(
@@ -189,8 +189,8 @@ export function createConnectProtocol(
                 options.jsonOptions
               );
             }
-            const input = parse(inputResult.value.data);
             try {
+              const input = parse(inputResult.value.data);
               for await (const output of spec.impl(input, context)) {
                 if (!res.headersSent) {
                   res.writeHead(

--- a/packages/connect-node/src/grpc-web-protocol.ts
+++ b/packages/connect-node/src/grpc-web-protocol.ts
@@ -101,9 +101,9 @@ export function createGrpcWebProtocol(
                 new ConnectError("Missing input message", Code.Internal)
               );
             }
-            const input = parse(inputResult.value.data);
             let output: O | PartialMessage<O>;
             try {
+              const input = parse(inputResult.value.data);
               output = await spec.impl(input, context);
             } catch (e) {
               return await endWithGrpcWebTrailer(
@@ -171,8 +171,8 @@ export function createGrpcWebProtocol(
                 )
               );
             }
-            const input = parse(inputResult.value.data);
             try {
+              const input = parse(inputResult.value.data);
               for await (const output of spec.impl(input, context)) {
                 if (!res.headersSent) {
                   res.writeHead(


### PR DESCRIPTION
This is already handled for bidi and client streaming methods but not for unary & server streaming.

Currently, when passing invalid JSON (or nothing), the server crashes while trying to parse the input as JSON.