### PR TITLE
add method and service info to the handler context

### DIFF
--- a/packages/connect-node/src/connect-protocol.ts
+++ b/packages/connect-node/src/connect-protocol.ts
@@ -92,7 +92,7 @@ export function createConnectProtocol(
                 "Unsupported Media Type"
               );
             }
-            const context: HandlerContext<I, O> = {
+            const context: HandlerContext = {
               method: spec.method,
               service: spec.service,
               requestHeader: nodeHeaderToWebHeader(req.headers),
@@ -153,7 +153,7 @@ export function createConnectProtocol(
                 "Unsupported Media Type"
               );
             }
-            const context: HandlerContext<I, O> = {
+            const context: HandlerContext = {
               method: spec.method,
               service: spec.service,
               requestHeader: nodeHeaderToWebHeader(req.headers),
@@ -242,7 +242,7 @@ export function createConnectProtocol(
                 "Unsupported Media Type"
               );
             }
-            const context: HandlerContext<I, O> = {
+            const context: HandlerContext = {
               method: spec.method,
               service: spec.service,
               requestHeader: nodeHeaderToWebHeader(req.headers),
@@ -325,7 +325,7 @@ export function createConnectProtocol(
                 "Unsupported Media Type"
               );
             }
-            const context: HandlerContext<I, O> = {
+            const context: HandlerContext = {
               method: spec.method,
               service: spec.service,
               requestHeader: nodeHeaderToWebHeader(req.headers),

--- a/packages/connect-node/src/connect-protocol.ts
+++ b/packages/connect-node/src/connect-protocol.ts
@@ -92,7 +92,9 @@ export function createConnectProtocol(
                 "Unsupported Media Type"
               );
             }
-            const context: HandlerContext = {
+            const context: HandlerContext<I, O> = {
+              method: spec.method,
+              service: spec.service,
               requestHeader: nodeHeaderToWebHeader(req.headers),
               responseHeader: connectCreateResponseHeader(
                 spec.method.kind,
@@ -151,7 +153,9 @@ export function createConnectProtocol(
                 "Unsupported Media Type"
               );
             }
-            const context: HandlerContext = {
+            const context: HandlerContext<I, O> = {
+              method: spec.method,
+              service: spec.service,
               requestHeader: nodeHeaderToWebHeader(req.headers),
               responseHeader: connectCreateResponseHeader(
                 spec.method.kind,
@@ -238,7 +242,9 @@ export function createConnectProtocol(
                 "Unsupported Media Type"
               );
             }
-            const context: HandlerContext = {
+            const context: HandlerContext<I, O> = {
+              method: spec.method,
+              service: spec.service,
               requestHeader: nodeHeaderToWebHeader(req.headers),
               responseHeader: connectCreateResponseHeader(
                 spec.method.kind,
@@ -319,7 +325,9 @@ export function createConnectProtocol(
                 "Unsupported Media Type"
               );
             }
-            const context: HandlerContext = {
+            const context: HandlerContext<I, O> = {
+              method: spec.method,
+              service: spec.service,
               requestHeader: nodeHeaderToWebHeader(req.headers),
               responseHeader: connectCreateResponseHeader(
                 spec.method.kind,

--- a/packages/connect-node/src/grpc-web-protocol.ts
+++ b/packages/connect-node/src/grpc-web-protocol.ts
@@ -81,7 +81,9 @@ export function createGrpcWebProtocol(
                 "Unsupported Media Type"
               );
             }
-            const context: HandlerContext = {
+            const context: HandlerContext<I, O> = {
+              method: spec.method,
+              service: spec.service,
               requestHeader: nodeHeaderToWebHeader(req.headers),
               responseHeader: grpcWebCreateResponseHeader(type.binary),
               responseTrailer: new Headers(),
@@ -138,7 +140,9 @@ export function createGrpcWebProtocol(
                 "Unsupported Media Type"
               );
             }
-            const context: HandlerContext = {
+            const context: HandlerContext<I, O> = {
+              method: spec.method,
+              service: spec.service,
               requestHeader: nodeHeaderToWebHeader(req.headers),
               responseHeader: grpcWebCreateResponseHeader(type.binary),
               responseTrailer: new Headers(),
@@ -214,7 +218,9 @@ export function createGrpcWebProtocol(
                 "Unsupported Media Type"
               );
             }
-            const context: HandlerContext = {
+            const context: HandlerContext<I, O> = {
+              method: spec.method,
+              service: spec.service,
               requestHeader: nodeHeaderToWebHeader(req.headers),
               responseHeader: grpcWebCreateResponseHeader(type.binary),
               responseTrailer: new Headers(),
@@ -285,7 +291,9 @@ export function createGrpcWebProtocol(
                 "Unsupported Media Type"
               );
             }
-            const context: HandlerContext = {
+            const context: HandlerContext<I, O> = {
+              method: spec.method,
+              service: spec.service,
               requestHeader: nodeHeaderToWebHeader(req.headers),
               responseHeader: grpcWebCreateResponseHeader(type.binary),
               responseTrailer: new Headers(),

--- a/packages/connect-node/src/grpc-web-protocol.ts
+++ b/packages/connect-node/src/grpc-web-protocol.ts
@@ -81,7 +81,7 @@ export function createGrpcWebProtocol(
                 "Unsupported Media Type"
               );
             }
-            const context: HandlerContext<I, O> = {
+            const context: HandlerContext = {
               method: spec.method,
               service: spec.service,
               requestHeader: nodeHeaderToWebHeader(req.headers),
@@ -140,7 +140,7 @@ export function createGrpcWebProtocol(
                 "Unsupported Media Type"
               );
             }
-            const context: HandlerContext<I, O> = {
+            const context: HandlerContext = {
               method: spec.method,
               service: spec.service,
               requestHeader: nodeHeaderToWebHeader(req.headers),
@@ -218,7 +218,7 @@ export function createGrpcWebProtocol(
                 "Unsupported Media Type"
               );
             }
-            const context: HandlerContext<I, O> = {
+            const context: HandlerContext = {
               method: spec.method,
               service: spec.service,
               requestHeader: nodeHeaderToWebHeader(req.headers),
@@ -291,7 +291,7 @@ export function createGrpcWebProtocol(
                 "Unsupported Media Type"
               );
             }
-            const context: HandlerContext<I, O> = {
+            const context: HandlerContext = {
               method: spec.method,
               service: spec.service,
               requestHeader: nodeHeaderToWebHeader(req.headers),

--- a/packages/connect-node/src/implementation.ts
+++ b/packages/connect-node/src/implementation.ts
@@ -79,7 +79,12 @@ interface MI<
 }
 
 // TODO document
-export interface HandlerContext {
+export interface HandlerContext<
+  I extends Message<I> = AnyMessage,
+  O extends Message<O> = AnyMessage
+> {
+  method: MethodInfo<I, O>;
+  service: ServiceType;
   requestHeader: Headers;
   responseHeader: Headers;
   responseTrailer: Headers;
@@ -90,7 +95,7 @@ export interface HandlerContext {
  */
 export type UnaryImpl<I extends Message<I>, O extends Message<O>> = (
   request: I,
-  context: HandlerContext
+  context: HandlerContext<I, O>
 ) => Promise<O> | Promise<PartialMessage<O>> | O | PartialMessage<O>;
 
 /**
@@ -99,7 +104,7 @@ export type UnaryImpl<I extends Message<I>, O extends Message<O>> = (
  */
 export type ClientStreamingImpl<I extends Message<I>, O extends Message<O>> = (
   requests: AsyncIterable<I>,
-  context: HandlerContext
+  context: HandlerContext<I, O>
 ) => Promise<O> | Promise<PartialMessage<O>>;
 
 /**
@@ -108,7 +113,7 @@ export type ClientStreamingImpl<I extends Message<I>, O extends Message<O>> = (
  */
 export type ServerStreamingImpl<I extends Message<I>, O extends Message<O>> = (
   request: I,
-  context: HandlerContext
+  context: HandlerContext<I, O>
 ) => AsyncIterable<O> | AsyncIterable<PartialMessage<O>>;
 
 /**
@@ -117,5 +122,5 @@ export type ServerStreamingImpl<I extends Message<I>, O extends Message<O>> = (
  */
 export type BiDiStreamingImpl<I extends Message<I>, O extends Message<O>> = (
   requests: AsyncIterable<I>,
-  context: HandlerContext
+  context: HandlerContext<I, O>
 ) => AsyncIterable<O> | AsyncIterable<PartialMessage<O>>;

--- a/packages/connect-node/src/implementation.ts
+++ b/packages/connect-node/src/implementation.ts
@@ -79,11 +79,8 @@ interface MI<
 }
 
 // TODO document
-export interface HandlerContext<
-  I extends Message<I> = AnyMessage,
-  O extends Message<O> = AnyMessage
-> {
-  method: MethodInfo<I, O>;
+export interface HandlerContext {
+  method: MethodInfo;
   service: ServiceType;
   requestHeader: Headers;
   responseHeader: Headers;
@@ -95,7 +92,7 @@ export interface HandlerContext<
  */
 export type UnaryImpl<I extends Message<I>, O extends Message<O>> = (
   request: I,
-  context: HandlerContext<I, O>
+  context: HandlerContext
 ) => Promise<O> | Promise<PartialMessage<O>> | O | PartialMessage<O>;
 
 /**
@@ -104,7 +101,7 @@ export type UnaryImpl<I extends Message<I>, O extends Message<O>> = (
  */
 export type ClientStreamingImpl<I extends Message<I>, O extends Message<O>> = (
   requests: AsyncIterable<I>,
-  context: HandlerContext<I, O>
+  context: HandlerContext
 ) => Promise<O> | Promise<PartialMessage<O>>;
 
 /**
@@ -113,7 +110,7 @@ export type ClientStreamingImpl<I extends Message<I>, O extends Message<O>> = (
  */
 export type ServerStreamingImpl<I extends Message<I>, O extends Message<O>> = (
   request: I,
-  context: HandlerContext<I, O>
+  context: HandlerContext
 ) => AsyncIterable<O> | AsyncIterable<PartialMessage<O>>;
 
 /**
@@ -122,5 +119,5 @@ export type ServerStreamingImpl<I extends Message<I>, O extends Message<O>> = (
  */
 export type BiDiStreamingImpl<I extends Message<I>, O extends Message<O>> = (
   requests: AsyncIterable<I>,
-  context: HandlerContext<I, O>
+  context: HandlerContext
 ) => AsyncIterable<O> | AsyncIterable<PartialMessage<O>>;


### PR DESCRIPTION
Not sure if you want to have those generics on the HandlerContext interface. They help to narrow the method info type slightly but don't add that much value. Your call.