### PR TITLE
fix method implementation return types

### DIFF
--- a/packages/connect-node/src/implementation.ts
+++ b/packages/connect-node/src/implementation.ts
@@ -93,7 +93,7 @@ export interface HandlerContext {
 export type UnaryImpl<I extends Message<I>, O extends Message<O>> = (
   request: I,
   context: HandlerContext
-) => Promise<O> | Promise<PartialMessage<O>> | O | PartialMessage<O>;
+) => Promise<O | PartialMessage<O>> | O | PartialMessage<O>;
 
 /**
  * ClientStreamingImpl is the signature of the implementation of a
@@ -102,7 +102,7 @@ export type UnaryImpl<I extends Message<I>, O extends Message<O>> = (
 export type ClientStreamingImpl<I extends Message<I>, O extends Message<O>> = (
   requests: AsyncIterable<I>,
   context: HandlerContext
-) => Promise<O> | Promise<PartialMessage<O>>;
+) => Promise<O | PartialMessage<O>>;
 
 /**
  * ServerStreamingImpl is the signature of the implementation of a
@@ -111,7 +111,7 @@ export type ClientStreamingImpl<I extends Message<I>, O extends Message<O>> = (
 export type ServerStreamingImpl<I extends Message<I>, O extends Message<O>> = (
   request: I,
   context: HandlerContext
-) => AsyncIterable<O> | AsyncIterable<PartialMessage<O>>;
+) => AsyncIterable<O | PartialMessage<O>>;
 
 /**
  * BiDiStreamingImpl is the signature of the implementation of a bi-di
@@ -120,4 +120,4 @@ export type ServerStreamingImpl<I extends Message<I>, O extends Message<O>> = (
 export type BiDiStreamingImpl<I extends Message<I>, O extends Message<O>> = (
   requests: AsyncIterable<I>,
   context: HandlerContext
-) => AsyncIterable<O> | AsyncIterable<PartialMessage<O>>;
+) => AsyncIterable<O | PartialMessage<O>>;


### PR DESCRIPTION
Especially for the stream handlers, there's a difference between ...

```typescript
AsyncIterable<O> | AsyncIterable<PartialMessage<O>>
```

vs. 

```typescript
AsyncIterable<O | PartialMessage<O>>
```

I believe the latter is actually what we want here (so the iterable can alternate between the two, if that's desirable even).

Either way, typescript seems to struggle also with `Promise<O> | Promise<PartialMessage<O>>` when used with some generic decorators that I was playing around with.