### PR TITLE
Support compression in the Connect protocol handler, and in Connect http2 clients

### DIFF
--- a/packages/connect-core/src/connect-end-stream.ts
+++ b/packages/connect-core/src/connect-end-stream.ts
@@ -24,7 +24,8 @@ import { connectErrorToJson } from "./connect-error-to-json.js";
 import { appendHeaders } from "./http-headers.js";
 
 /**
- *
+ * connectEndStreamFlag indicates that the data in a EnvelopedMessage
+ * is a EndStreamResponse of the Connect protocol.
  */
 export const connectEndStreamFlag = 0b00000010;
 

--- a/packages/connect-node-test/src/badweather/unsupported-content-encoding.spec.ts
+++ b/packages/connect-node-test/src/badweather/unsupported-content-encoding.spec.ts
@@ -1,0 +1,82 @@
+// Copyright 2021-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { TestService } from "../gen/grpc/testing/test_connectweb.js";
+import { createTestServers } from "../helpers/testserver.js";
+import {
+  Code,
+  connectEndStreamFromJson,
+  connectErrorFromJson,
+  createMethodUrl,
+} from "@bufbuild/connect-core";
+import { http2Request } from "../helpers/http2-request.js";
+import type { MethodInfo } from "@bufbuild/protobuf";
+import type * as http from "http";
+import type { JsonValue } from "@bufbuild/protobuf";
+
+describe("unsupported content encoding", () => {
+  const servers = createTestServers();
+  beforeAll(async () => await servers.start());
+
+  servers.describeServers(
+    ["@bufbuild/connect-node (h2c)", "connect-go (h2)"],
+    (server, serverName) => {
+      function req(method: MethodInfo, headers: http.OutgoingHttpHeaders) {
+        const url = createMethodUrl(server.getUrl(), TestService, method);
+        if (serverName == "connect-go (h2)") {
+          return http2Request("POST", url, headers, undefined, {
+            rejectUnauthorized: false, // TODO set up cert for go server correctly
+          });
+        }
+        return http2Request("POST", url, headers);
+      }
+      describe("Connect unary method", function () {
+        const reqUnary = req.bind(null, TestService.methods.unaryCall);
+        it("should raise code unimplemented for unsupported content-encoding", async () => {
+          const res = await reqUnary({
+            "content-type": "application/json",
+            "content-encoding": "banana",
+          });
+          expect(res.status).toBe(404);
+          const err = connectErrorFromJson(
+            JSON.parse(new TextDecoder().decode(res.body)) as JsonValue
+          );
+          expect(err.code).toBe(Code.Unimplemented);
+          expect(err.rawMessage).toMatch(
+            /^unknown compression "banana": supported encodings are gzip(, [a-z]+)*$/
+          );
+        });
+      });
+      describe("Connect streaming method", function () {
+        const reqStreaming = req.bind(
+          null,
+          TestService.methods.streamingInputCall
+        );
+        it("should raise code unimplemented for unsupported connect-content-encoding", async () => {
+          const res = await reqStreaming({
+            "content-type": "application/connect+json",
+            "connect-content-encoding": "banana",
+          });
+          const endStream = connectEndStreamFromJson(res.body.subarray(5));
+          expect(endStream.error?.code).toBe(Code.Unimplemented);
+          expect(endStream.error?.rawMessage).toMatch(
+            /^unknown compression "banana": supported encodings are gzip(, [a-z]+)*$/
+          );
+        });
+      });
+    }
+  );
+
+  afterAll(async () => await servers.stop());
+});

--- a/packages/connect-node-test/src/compression.spec.ts
+++ b/packages/connect-node-test/src/compression.spec.ts
@@ -1,0 +1,88 @@
+// Copyright 2021-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  compressionBrotli,
+  compressionGzip,
+  connectErrorFromReason,
+} from "@bufbuild/connect-node";
+import * as zlib from "zlib";
+import { ConnectError } from "@bufbuild/connect-core";
+
+describe("compression", () => {
+  const payload = new TextEncoder().encode(
+    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+  );
+
+  const table = [
+    { compression: compressionGzip, payloadCompressed: zlib.gzipSync(payload) },
+    {
+      compression: compressionBrotli,
+      payloadCompressed: zlib.brotliCompressSync(payload),
+    },
+  ];
+
+  for (const { compression, payloadCompressed } of table) {
+    describe(compression.name, function () {
+      it("should compress", async () => {
+        const b = await compression.compress(payload);
+        expect(b.length < payload.length).toBeTrue();
+      });
+      it("should decompress", async () => {
+        const b = await compression.decompress(payloadCompressed, 0xffffffff);
+        const equal = payload.every((value, index) => b[index] === value);
+        expect(equal).toBeTrue();
+      });
+      it("should raise resource_exhausted if maxReadBytes exceeded", async () => {
+        try {
+          await compression.decompress(payloadCompressed, 2);
+          fail("excepted an error");
+        } catch (e) {
+          expect(e).toBeInstanceOf(ConnectError);
+          expect(connectErrorFromReason(e).message).toBe(
+            "[resource_exhausted] message is larger than configured readMaxBytes 2 after decompression"
+          );
+        }
+      });
+      it("should raise invalid_argument on invalid input", async () => {
+        try {
+          await compression.decompress(
+            new Uint8Array([0xde, 0xad, 0xbe, 0xef]),
+            0xffffffff
+          );
+          fail("excepted an error");
+        } catch (e) {
+          expect(e).toBeInstanceOf(ConnectError);
+          expect(connectErrorFromReason(e).message).toBe(
+            "[invalid_argument] decompression failed"
+          );
+        }
+      });
+      it("should raise internal error on excessive readMaxBytes", async () => {
+        try {
+          await compression.decompress(
+            new Uint8Array([0xde, 0xad, 0xbe, 0xef]),
+            Number.MAX_SAFE_INTEGER
+          );
+          fail("excepted an error");
+        } catch (e) {
+          expect(e).toBeInstanceOf(ConnectError);
+          expect(connectErrorFromReason(e).message).toBe(
+            "[internal] decompression failed"
+          );
+        }
+      });
+    });
+  }
+});

--- a/packages/connect-node-test/src/helpers/testserver.ts
+++ b/packages/connect-node-test/src/helpers/testserver.ts
@@ -16,6 +16,7 @@ import * as http2 from "http2";
 import * as http from "http";
 import * as https from "https";
 import {
+  compressionGzip,
   createConnectHttp2Transport,
   createConnectHttpTransport,
   createGrpcWebHttp2Transport,
@@ -316,42 +317,44 @@ vKy9wyvtUtg=
         useBinaryFormat: true,
       }),
     // Connect
-    "@bufbuild/connect-node (Connect, binary, http2) against @bufbuild/connect-node (h2c)":
+    "@bufbuild/connect-node (Connect, binary, http2, gzip) against @bufbuild/connect-node (h2c)":
       (options?: Record<string, unknown>) =>
         createConnectHttp2Transport({
           ...options,
           baseUrl: servers["@bufbuild/connect-node (h2c)"].getUrl(),
           useBinaryFormat: true,
+          sendCompression: compressionGzip,
         }),
-    "@bufbuild/connect-node (Connect, JSON, http2) against @bufbuild/connect-node (h2c)":
+    "@bufbuild/connect-node (Connect, JSON, http2, gzip) against @bufbuild/connect-node (h2c)":
       (options?: Record<string, unknown>) =>
         createConnectHttp2Transport({
           ...options,
           baseUrl: servers["@bufbuild/connect-node (h2c)"].getUrl(),
           useBinaryFormat: false,
+          sendCompression: compressionGzip,
         }),
-    "@bufbuild/connect-node (Connect, binary, http2) against connect-go (h1)": (
-      options?: Record<string, unknown>
-    ) =>
-      createConnectHttp2Transport({
-        ...options,
-        baseUrl: servers["connect-go (h1)"].getUrl(),
-        http2Options: {
-          rejectUnauthorized: false, // TODO set up cert for go server correctly
-        },
-        useBinaryFormat: true,
-      }),
-    "@bufbuild/connect-node (Connect, JSON, http2) against connect-go (h1)": (
-      options?: Record<string, unknown>
-    ) =>
-      createConnectHttp2Transport({
-        ...options,
-        baseUrl: servers["connect-go (h1)"].getUrl(),
-        http2Options: {
-          rejectUnauthorized: false, // TODO set up cert for go server correctly
-        },
-        useBinaryFormat: false,
-      }),
+    "@bufbuild/connect-node (Connect, binary, http2, gzip) against connect-go (h1)":
+      (options?: Record<string, unknown>) =>
+        createConnectHttp2Transport({
+          ...options,
+          baseUrl: servers["connect-go (h1)"].getUrl(),
+          http2Options: {
+            rejectUnauthorized: false, // TODO set up cert for go server correctly
+          },
+          useBinaryFormat: true,
+          sendCompression: compressionGzip,
+        }),
+    "@bufbuild/connect-node (Connect, JSON, http2, gzip) against connect-go (h1)":
+      (options?: Record<string, unknown>) =>
+        createConnectHttp2Transport({
+          ...options,
+          baseUrl: servers["connect-go (h1)"].getUrl(),
+          http2Options: {
+            rejectUnauthorized: false, // TODO set up cert for go server correctly
+          },
+          useBinaryFormat: false,
+          sendCompression: compressionGzip,
+        }),
     "@bufbuild/connect-node (Connect, JSON, http) against @bufbuild/connect-node (h1)":
       (options?: Record<string, unknown>) =>
         createConnectHttpTransport({

--- a/packages/connect-node/src/compression.ts
+++ b/packages/connect-node/src/compression.ts
@@ -1,0 +1,96 @@
+// Copyright 2021-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as zlib from "zlib";
+import { promisify } from "util";
+import { Code, ConnectError } from "@bufbuild/connect-core";
+
+export interface Compression {
+  name: string;
+  compress: (bytes: Uint8Array) => Promise<Uint8Array>;
+  decompress: (bytes: Uint8Array, readMaxBytes: number) => Promise<Uint8Array>;
+}
+
+const gzip = promisify(zlib.gzip);
+const gunzip = promisify(zlib.gunzip);
+const brotliCompress = promisify(zlib.brotliCompress);
+const brotliDecompress = promisify(zlib.brotliDecompress);
+
+export const compressionGzip: Compression = {
+  name: "gzip",
+  compress(bytes) {
+    return gzip(bytes, {});
+  },
+  decompress(bytes, readMaxBytes) {
+    return wrapZLibErrors(
+      gunzip(bytes, {
+        maxOutputLength: readMaxBytes,
+      }),
+      readMaxBytes
+    );
+  },
+};
+
+export const compressionBrotli: Compression = {
+  name: "brotli",
+  compress(bytes) {
+    return brotliCompress(bytes, {});
+  },
+  decompress(bytes, readMaxBytes) {
+    return wrapZLibErrors(
+      brotliDecompress(bytes, {
+        maxOutputLength: readMaxBytes,
+      }),
+      readMaxBytes
+    );
+  },
+};
+
+function wrapZLibErrors<T>(
+  promise: Promise<T>,
+  readMaxBytes: number
+): Promise<T> {
+  return promise.catch((e) => {
+    const code = getNodeErrorCode(e);
+    // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check
+    switch (code) {
+      case "ERR_BUFFER_TOO_LARGE":
+        e = new ConnectError(
+          `message is larger than configured readMaxBytes ${readMaxBytes} after decompression`,
+          Code.ResourceExhausted
+        );
+        break;
+      case "Z_DATA_ERROR":
+      case "ERR_PADDING_2":
+        // TODO(TCN-785) we may want to preserve the cause, but not in the connect error message
+        e = new ConnectError("decompression failed", Code.InvalidArgument);
+        break;
+      default:
+        // TODO(TCN-785) we may want to preserve the cause, but not in the connect error message
+        e = new ConnectError("decompression failed", Code.Internal);
+        break;
+    }
+    return Promise.reject(e);
+  });
+}
+
+function getNodeErrorCode(e: unknown): string | undefined {
+  if (e instanceof Error && "code" in e) {
+    const eWithCode = e as { code: unknown };
+    if (typeof eWithCode.code == "string") {
+      return eWithCode.code;
+    }
+  }
+  return undefined;
+}

--- a/packages/connect-node/src/connect-protocol.ts
+++ b/packages/connect-node/src/connect-protocol.ts
@@ -51,11 +51,33 @@ import {
   readToEnd,
   write,
 } from "./private/io.js";
+import type { Compression } from "./compression.js";
+import { compressionBrotli, compressionGzip } from "./compression.js";
+import { validateReadMaxBytesOption } from "./private/validate-read-max-bytes-option.js";
+import { connectErrorFromNodeReason } from "./private/connect-error-from-node.js";
+import { compressionNegotiate } from "./private/compression-negotiate.js";
+
+/**
+ * compressedFlag indicates that the data in a EnvelopedMessage is
+ * compressed. It has the same meaning in the gRPC-Web, gRPC-HTTP2,
+ * and Connect protocols.
+ */
+const compressedFlag = 0b00000001;
+const headerUnaryEncoding = "Content-Encoding";
+const headerStreamEncoding = "Connect-Content-Encoding";
+const headerUnaryAcceptEncoding = "Accept-Encoding";
+const headerStreamAcceptEncoding = "Connect-Accept-Encoding";
+const headerContentType = "Content-Type";
 
 /**
  * Options for creating a Connect Protocol instance.
  */
 interface CreateConnectProtocolOptions {
+  // TODO document
+  acceptCompression?: Compression[];
+  compressMinBytes?: number;
+  readMaxBytes?: number;
+  sendMaxBytes?: number;
   jsonOptions?: Partial<JsonReadOptions & JsonWriteOptions>;
   binaryOptions?: Partial<BinaryReadOptions & BinaryWriteOptions>;
 }
@@ -66,6 +88,12 @@ interface CreateConnectProtocolOptions {
 export function createConnectProtocol(
   options: CreateConnectProtocolOptions
 ): Protocol {
+  const readMaxBytes = validateReadMaxBytesOption(options.readMaxBytes);
+  const compressMinBytes = options.compressMinBytes ?? 0;
+  const acceptCompression = options.acceptCompression ?? [
+    compressionGzip,
+    compressionBrotli,
+  ];
   return {
     supportsMediaType: (type) => !!connectParseContentType(type),
 
@@ -75,8 +103,9 @@ export function createConnectProtocol(
       switch (spec.kind) {
         case MethodKind.Unary:
           return async (req, res) => {
+            const requestHeader = nodeHeaderToWebHeader(req.headers);
             const type = connectParseContentType(
-              req.headers["content-type"] ?? null
+              requestHeader.get(headerContentType) ?? null
             );
             if (type === undefined) {
               return await endWithHttpStatus(
@@ -95,13 +124,37 @@ export function createConnectProtocol(
             const context: HandlerContext = {
               method: spec.method,
               service: spec.service,
-              requestHeader: nodeHeaderToWebHeader(req.headers),
+              requestHeader: requestHeader,
               responseHeader: connectCreateResponseHeader(
                 spec.method.kind,
                 type.binary
               ),
               responseTrailer: new Headers(),
             };
+            const {
+              requestCompression,
+              responseCompression,
+              unsupportedError,
+              supportedNames,
+            } = compressionNegotiate(
+              acceptCompression,
+              requestHeader.get(headerUnaryEncoding),
+              requestHeader.get(headerUnaryAcceptEncoding)
+            );
+            if (unsupportedError) {
+              unsupportedError.metadata.set(
+                headerUnaryAcceptEncoding,
+                supportedNames
+              );
+              return await endWithConnectUnaryError(
+                res,
+                context,
+                unsupportedError,
+                options.jsonOptions,
+                undefined,
+                compressMinBytes
+              );
+            }
             const { normalize, parse, serialize } =
               createServerMethodSerializers(
                 options.jsonOptions,
@@ -109,17 +162,50 @@ export function createConnectProtocol(
                 spec.method,
                 type.binary
               );
-
-            const input = parse(await readToEnd(req));
+            let requestBody = await readToEnd(req); // TODO(TCN-785) honor readMaxBytes
+            if (requestCompression) {
+              requestBody = await requestCompression.decompress(
+                requestBody,
+                readMaxBytes
+              );
+            }
             let output: O | PartialMessage<O>;
+            const input = parse(requestBody);
             try {
               output = await spec.impl(input, context);
             } catch (e) {
+              let ce: ConnectError;
+              if (e instanceof ConnectError) {
+                ce = e;
+                context.responseHeader = appendHeaders(
+                  context.responseHeader,
+                  e.metadata
+                );
+              } else if (connectErrorFromNodeReason(e).code == Code.Canceled) {
+                ce = new ConnectError("operation canceled", Code.Canceled);
+              } else {
+                // TODO(TCN-785) We want to elide the error message for the client, but still
+                //    make it available for logging. We may have to add a "cause" property.
+                ce = new ConnectError("internal error", Code.Internal);
+              }
               return await endWithConnectUnaryError(
                 res,
                 context,
-                connectErrorFromReason(e),
-                options.jsonOptions
+                ce,
+                options.jsonOptions,
+                responseCompression,
+                compressMinBytes
+              );
+            }
+            let responseBody = serialize(normalize(output));
+            if (
+              responseCompression &&
+              responseBody.length >= compressMinBytes
+            ) {
+              responseBody = await responseCompression.compress(responseBody);
+              context.responseHeader.set(
+                headerUnaryEncoding,
+                responseCompression.name
               );
             }
             res.writeHead(
@@ -131,13 +217,14 @@ export function createConnectProtocol(
                 )
               )
             );
-            await write(res, serialize(normalize(output)));
+            await write(res, responseBody);
             await end(res);
           };
         case MethodKind.ServerStreaming: {
           return async (req, res) => {
+            const requestHeader = nodeHeaderToWebHeader(req.headers);
             const type = connectParseContentType(
-              req.headers["content-type"] ?? null
+              requestHeader.get(headerContentType) ?? null
             );
             if (type === undefined) {
               return await endWithHttpStatus(
@@ -156,13 +243,43 @@ export function createConnectProtocol(
             const context: HandlerContext = {
               method: spec.method,
               service: spec.service,
-              requestHeader: nodeHeaderToWebHeader(req.headers),
+              requestHeader,
               responseHeader: connectCreateResponseHeader(
                 spec.method.kind,
                 type.binary
               ),
               responseTrailer: new Headers(),
             };
+            const {
+              requestCompression,
+              responseCompression,
+              unsupportedError,
+              supportedNames,
+            } = compressionNegotiate(
+              acceptCompression,
+              requestHeader.get(headerStreamEncoding),
+              requestHeader.get(headerStreamAcceptEncoding)
+            );
+            if (unsupportedError) {
+              unsupportedError.metadata.set(
+                headerStreamAcceptEncoding,
+                supportedNames
+              );
+              return await endWithConnectEndStream(
+                res,
+                context,
+                unsupportedError,
+                options.jsonOptions,
+                undefined,
+                compressMinBytes
+              );
+            }
+            if (responseCompression) {
+              context.responseHeader.set(
+                headerStreamEncoding,
+                responseCompression.name
+              );
+            }
             const { normalize, parse, serialize } =
               createServerMethodSerializers(
                 options.jsonOptions,
@@ -170,30 +287,29 @@ export function createConnectProtocol(
                 spec.method,
                 type.binary
               );
-
             const inputResult = await readEnvelope(req);
             if (inputResult.done) {
               return await endWithConnectEndStream(
                 res,
                 context,
                 new ConnectError("Missing input message", Code.Internal),
-                options.jsonOptions
+                options.jsonOptions,
+                responseCompression,
+                compressMinBytes
               );
             }
-            if (inputResult.value.flags !== 0b00000000) {
-              return await endWithConnectEndStream(
-                res,
-                context,
-                new ConnectError(
-                  `Unexpected input flags ${inputResult.value.flags.toString(
-                    2
-                  )}`,
-                  Code.Internal
-                ),
-                options.jsonOptions
-              );
+            const flags = inputResult.value.flags;
+            let data = inputResult.value.data;
+            if ((flags & compressedFlag) === compressedFlag) {
+              if (!requestCompression) {
+                throw new ConnectError(
+                  `received compressed envelope, but no content-encoding`,
+                  Code.InvalidArgument
+                );
+              }
+              data = await requestCompression.decompress(data, readMaxBytes);
             }
-            const input = parse(inputResult.value.data);
+            const input = parse(data);
             try {
               for await (const output of spec.impl(input, context)) {
                 if (!res.headersSent) {
@@ -202,31 +318,39 @@ export function createConnectProtocol(
                     webHeaderToNodeHeaders(context.responseHeader)
                   );
                 }
-                await write(
-                  res,
-                  encodeEnvelope(0b00000000, serialize(normalize(output)))
-                );
+                let data = serialize(normalize(output));
+                let flags = 0;
+                if (responseCompression && data.length >= compressMinBytes) {
+                  data = await responseCompression.compress(data);
+                  flags = flags | compressedFlag;
+                }
+                await write(res, encodeEnvelope(flags, data));
               }
             } catch (e) {
               return await endWithConnectEndStream(
                 res,
                 context,
                 connectErrorFromReason(e),
-                options.jsonOptions
+                options.jsonOptions,
+                responseCompression,
+                compressMinBytes
               );
             }
             return await endWithConnectEndStream(
               res,
               context,
               undefined,
-              options.jsonOptions
+              options.jsonOptions,
+              responseCompression,
+              compressMinBytes
             );
           };
         }
         case MethodKind.ClientStreaming: {
           return async (req, res) => {
+            const requestHeader = nodeHeaderToWebHeader(req.headers);
             const type = connectParseContentType(
-              req.headers["content-type"] ?? null
+              requestHeader.get(headerContentType) ?? null
             );
             if (type === undefined) {
               return await endWithHttpStatus(
@@ -252,6 +376,36 @@ export function createConnectProtocol(
               ),
               responseTrailer: new Headers(),
             };
+            const {
+              requestCompression,
+              responseCompression,
+              unsupportedError,
+              supportedNames,
+            } = compressionNegotiate(
+              acceptCompression,
+              requestHeader.get(headerStreamEncoding),
+              requestHeader.get(headerStreamAcceptEncoding)
+            );
+            if (unsupportedError) {
+              unsupportedError.metadata.set(
+                headerStreamAcceptEncoding,
+                supportedNames
+              );
+              return await endWithConnectEndStream(
+                res,
+                context,
+                unsupportedError,
+                options.jsonOptions,
+                undefined,
+                compressMinBytes
+              );
+            }
+            if (responseCompression) {
+              context.responseHeader.set(
+                headerStreamEncoding,
+                responseCompression.name
+              );
+            }
             const { normalize, parse, serialize } =
               createServerMethodSerializers(
                 options.jsonOptions,
@@ -259,27 +413,27 @@ export function createConnectProtocol(
                 spec.method,
                 type.binary
               );
-
             async function* input() {
               for (;;) {
                 const result = await readEnvelope(req);
                 if (result.done) {
                   break;
                 }
-                if (result.value.flags !== 0b00000000) {
-                  return await endWithConnectEndStream(
-                    res,
-                    context,
-                    new ConnectError(
-                      `Unexpected input flags ${result.value.flags.toString(
-                        2
-                      )}`,
-                      Code.Internal
-                    ),
-                    options.jsonOptions
+                const flags = result.value.flags;
+                let data = result.value.data;
+                if ((flags & compressedFlag) === compressedFlag) {
+                  if (!requestCompression) {
+                    throw new ConnectError(
+                      `received compressed envelope, but no content-encoding`,
+                      Code.InvalidArgument
+                    );
+                  }
+                  data = await requestCompression.decompress(
+                    data,
+                    readMaxBytes
                   );
                 }
-                yield parse(result.value.data);
+                yield parse(data);
               }
             }
             let output: O | PartialMessage<O>;
@@ -290,26 +444,34 @@ export function createConnectProtocol(
                 res,
                 context,
                 connectErrorFromReason(e),
-                options.jsonOptions
+                options.jsonOptions,
+                responseCompression,
+                compressMinBytes
               );
             }
             res.writeHead(200, webHeaderToNodeHeaders(context.responseHeader));
-            await write(
-              res,
-              encodeEnvelope(0b00000000, serialize(normalize(output)))
-            );
+            let data = serialize(normalize(output));
+            let flags = 0;
+            if (responseCompression && data.length >= compressMinBytes) {
+              data = await responseCompression.compress(data);
+              flags = flags | compressedFlag;
+            }
+            await write(res, encodeEnvelope(flags, data));
             return await endWithConnectEndStream(
               res,
               context,
               undefined,
-              options.jsonOptions
+              options.jsonOptions,
+              responseCompression,
+              compressMinBytes
             );
           };
         }
         case MethodKind.BiDiStreaming: {
           return async (req, res) => {
+            const requestHeader = nodeHeaderToWebHeader(req.headers);
             const type = connectParseContentType(
-              req.headers["content-type"] ?? null
+              requestHeader.get(headerContentType) ?? null
             );
             if (type === undefined) {
               return await endWithHttpStatus(
@@ -335,6 +497,36 @@ export function createConnectProtocol(
               ),
               responseTrailer: new Headers(),
             };
+            const {
+              requestCompression,
+              responseCompression,
+              unsupportedError,
+              supportedNames,
+            } = compressionNegotiate(
+              acceptCompression,
+              requestHeader.get(headerStreamEncoding),
+              requestHeader.get(headerStreamAcceptEncoding)
+            );
+            if (unsupportedError) {
+              unsupportedError.metadata.set(
+                headerUnaryAcceptEncoding,
+                supportedNames
+              );
+              return await endWithConnectUnaryError(
+                res,
+                context,
+                unsupportedError,
+                options.jsonOptions,
+                undefined,
+                compressMinBytes
+              );
+            }
+            if (responseCompression) {
+              context.responseHeader.set(
+                headerStreamEncoding,
+                responseCompression.name
+              );
+            }
             const { normalize, parse, serialize } =
               createServerMethodSerializers(
                 options.jsonOptions,
@@ -342,27 +534,27 @@ export function createConnectProtocol(
                 spec.method,
                 type.binary
               );
-
             async function* input() {
               for (;;) {
                 const result = await readEnvelope(req);
                 if (result.done) {
                   break;
                 }
-                if (result.value.flags !== 0b00000000) {
-                  return await endWithConnectEndStream(
-                    res,
-                    context,
-                    new ConnectError(
-                      `Unexpected input flags ${result.value.flags.toString(
-                        2
-                      )}`,
-                      Code.Internal
-                    ),
-                    options.jsonOptions
+                const flags = result.value.flags;
+                let data = result.value.data;
+                if ((flags & compressedFlag) === compressedFlag) {
+                  if (!requestCompression) {
+                    throw new ConnectError(
+                      `received compressed envelope, but no content-encoding ON THE SERVER`,
+                      Code.InvalidArgument
+                    );
+                  }
+                  data = await requestCompression.decompress(
+                    data,
+                    readMaxBytes
                   );
                 }
-                yield parse(result.value.data);
+                yield parse(data);
               }
             }
             try {
@@ -373,24 +565,31 @@ export function createConnectProtocol(
                     webHeaderToNodeHeaders(context.responseHeader)
                   );
                 }
-                await write(
-                  res,
-                  encodeEnvelope(0b00000000, serialize(normalize(output)))
-                );
+                let data = serialize(normalize(output));
+                let flags = 0;
+                if (responseCompression && data.length >= compressMinBytes) {
+                  data = await responseCompression.compress(data);
+                  flags = flags | compressedFlag;
+                }
+                await write(res, encodeEnvelope(flags, data));
               }
             } catch (e) {
               return await endWithConnectEndStream(
                 res,
                 context,
                 connectErrorFromReason(e),
-                options.jsonOptions
+                options.jsonOptions,
+                responseCompression,
+                compressMinBytes
               );
             }
             return await endWithConnectEndStream(
               res,
               context,
               undefined,
-              options.jsonOptions
+              options.jsonOptions,
+              responseCompression,
+              compressMinBytes
             );
           };
         }
@@ -403,21 +602,23 @@ function connectCreateResponseHeader(
   methodKind: MethodKind,
   useBinaryFormat: boolean
 ): Headers {
-  let type = "application/";
+  let contentTypeValue = "application/";
   if (methodKind != MethodKind.Unary) {
-    type += "connect+";
+    contentTypeValue += "connect+";
   }
-  type += useBinaryFormat ? "proto" : "json";
-  return new Headers({
-    "Content-Type": type,
-  });
+  contentTypeValue += useBinaryFormat ? "proto" : "json";
+  const result = new Headers();
+  result.set(headerContentType, contentTypeValue);
+  return result;
 }
 
 async function endWithConnectEndStream(
   res: http.ServerResponse | http2.Http2ServerResponse,
   context: HandlerContext,
   error: ConnectError | undefined,
-  jsonWriteOptions: Partial<JsonWriteOptions> | undefined
+  jsonWriteOptions: Partial<JsonWriteOptions> | undefined,
+  responseCompression: Compression | undefined,
+  compressMinBytes: number
 ) {
   if (!res.headersSent) {
     res.writeHead(200, webHeaderToNodeHeaders(context.responseHeader));
@@ -427,10 +628,13 @@ async function endWithConnectEndStream(
     error,
     jsonWriteOptions
   );
-  await write(
-    res,
-    encodeEnvelope(connectEndStreamFlag, jsonSerialize(endStreamJson))
-  );
+  let data = jsonSerialize(endStreamJson);
+  let flags = connectEndStreamFlag;
+  if (responseCompression && data.length >= compressMinBytes) {
+    data = await responseCompression.compress(data);
+    flags = flags | compressedFlag;
+  }
+  await write(res, encodeEnvelope(flags, data));
   await end(res);
 }
 
@@ -438,16 +642,23 @@ async function endWithConnectUnaryError(
   res: http.ServerResponse | http2.Http2ServerResponse,
   context: HandlerContext,
   error: ConnectError,
-  jsonWriteOptions: Partial<JsonWriteOptions> | undefined
+  jsonWriteOptions: Partial<JsonWriteOptions> | undefined,
+  responseCompression: Compression | undefined,
+  compressMinBytes: number
 ): Promise<void> {
-  const statusCode = connectCodeToHttpStatus(error.code);
   const header = appendHeaders(
     connectTrailerMux(context.responseHeader, context.responseTrailer),
     error.metadata
   );
-  header.set("Content-Type", "application/json");
-  res.writeHead(statusCode, webHeaderToNodeHeaders(header));
+  header.set(headerContentType, "application/json");
   const json = connectErrorToJson(error, jsonWriteOptions);
-  await write(res, jsonSerialize(json));
+  let body = jsonSerialize(json);
+  if (responseCompression && body.length >= compressMinBytes) {
+    body = await responseCompression.compress(body);
+    header.set(headerUnaryEncoding, responseCompression.name);
+  }
+  const statusCode = connectCodeToHttpStatus(error.code);
+  res.writeHead(statusCode, webHeaderToNodeHeaders(header));
+  await write(res, body);
   await end(res);
 }

--- a/packages/connect-node/src/grpc-http2-transport.ts
+++ b/packages/connect-node/src/grpc-http2-transport.ts
@@ -100,8 +100,7 @@ export interface GrpcHttp2TransportOptions {
 }
 
 /**
- * Create a Transport for the gRPC protocol.
- *
+ * Create a Transport for the gRPC protocol using the Node.js `http2` package.
  */
 export function createGrpcHttp2Transport(
   options: GrpcHttp2TransportOptions

--- a/packages/connect-node/src/grpc-web-http2-transport.ts
+++ b/packages/connect-node/src/grpc-web-http2-transport.ts
@@ -49,6 +49,10 @@ import { webHeaderToNodeHeaders } from "./private/web-header-to-node-headers.js"
 import { connectErrorFromNodeReason } from "./private/connect-error-from-node.js";
 
 const messageFlag = 0b00000000;
+/**
+ * trailerFlag indicates that the data in a EnvelopedMessage
+ * is a set of trailers of the gRPC-web protocol.
+ */
 const trailerFlag = 0b10000000;
 
 /**
@@ -96,8 +100,8 @@ export interface GrpcWebHttp2TransportOptions {
 }
 
 /**
- * Create a Transport for the gRPC-web protocol.
- *
+ * Create a Transport for the gRPC-web protocol using the Node.js `http2`
+ * package.
  */
 export function createGrpcWebHttp2Transport(
   options: GrpcWebHttp2TransportOptions

--- a/packages/connect-node/src/index.ts
+++ b/packages/connect-node/src/index.ts
@@ -15,6 +15,7 @@
 export * from "./connect-http2-transport.js";
 export * from "./grpc-web-http2-transport.js";
 export * from "./grpc-http2-transport.js";
+export * from "./compression.js";
 export {
   Handler,
   createHandler,

--- a/packages/connect-node/src/private/compression-negotiate.ts
+++ b/packages/connect-node/src/private/compression-negotiate.ts
@@ -1,0 +1,75 @@
+// Copyright 2021-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { Compression } from "../compression.js";
+import { Code, ConnectError } from "@bufbuild/connect-core";
+
+/**
+ * compressionNegotiate validates the request encoding and determines
+ * the accepted response encoding.
+ *
+ * If the request encoding is not supported, the returned object contains
+ * the following properties:
+ * - "unsupportedError": A ConnectError that implementations must send
+ *   to the client.
+ * - "supportedNames": A comma-separated list of encodings that are
+ *   supported. The implementation must send this value in a protocol-
+ *   specific accept-encoding header.
+ */
+export function compressionNegotiate(
+  availableCompression: Compression[],
+  requestEncoding: string | null,
+  acceptedResponseEncodings: string | null
+): {
+  requestCompression?: Compression;
+  responseCompression?: Compression;
+  unsupportedError?: ConnectError;
+  supportedNames: string;
+} {
+  const supportedNames = availableCompression.map((c) => c.name).join(", ");
+  let requestCompression: Compression | undefined;
+  if (requestEncoding !== null && requestEncoding !== "identity") {
+    requestCompression = availableCompression.find(
+      (c) => c.name === requestEncoding
+    );
+    if (!requestCompression) {
+      // To comply with https://github.com/grpc/grpc/blob/master/doc/compression.md
+      // and the Connect protocol, we return code "unimplemented" and specify
+      // acceptable compression(s).
+      const err = new ConnectError(
+        `unknown compression "${requestEncoding}": supported encodings are ${supportedNames}`,
+        Code.Unimplemented
+      );
+      return { unsupportedError: err, supportedNames };
+    }
+  }
+  let responseCompression: Compression | undefined;
+  if (acceptedResponseEncodings === null || acceptedResponseEncodings === "") {
+    // Support asymmetric compression. This logic follows
+    // https://github.com/grpc/grpc/blob/master/doc/compression.md and common
+    // sense.
+    responseCompression = requestCompression;
+  } else {
+    const acceptNames = acceptedResponseEncodings
+      .split(",")
+      .map((n) => n.trim());
+    for (const name of acceptNames) {
+      responseCompression = availableCompression.find((c) => c.name === name);
+      if (responseCompression) {
+        break;
+      }
+    }
+  }
+  return { requestCompression, responseCompression, supportedNames };
+}

--- a/packages/connect-node/src/private/create-server-method-serializers.ts
+++ b/packages/connect-node/src/private/create-server-method-serializers.ts
@@ -49,8 +49,8 @@ export function createServerMethodSerializers<
         : new TextEncoder().encode(message.toJsonString(jsonOptions));
     } catch (e) {
       const m = e instanceof Error ? e.message : String(e);
-      const format = useBinaryFormat ? "binary format" : "json format";
-      throw new ConnectError(`${format}: ${m}`, Code.Internal);
+      const format = useBinaryFormat ? "proto" : "json";
+      throw new ConnectError(`serialize ${format}: ${m}`, Code.Internal);
     }
   }
 
@@ -62,8 +62,8 @@ export function createServerMethodSerializers<
         : method.I.fromJsonString(new TextDecoder().decode(bytes), jsonOptions);
     } catch (e) {
       const m = e instanceof Error ? e.message : String(e);
-      const format = useBinaryFormat ? "binary format" : "json format";
-      throw new ConnectError(`${format}: ${m}`, Code.InvalidArgument);
+      const format = useBinaryFormat ? "proto" : "json";
+      throw new ConnectError(`parse ${format}: ${m}`, Code.InvalidArgument);
     }
   }
 

--- a/packages/connect-node/src/private/validate-read-max-bytes-option.ts
+++ b/packages/connect-node/src/private/validate-read-max-bytes-option.ts
@@ -1,0 +1,35 @@
+// Copyright 2021-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Code, ConnectError } from "@bufbuild/connect-core";
+
+const maxReadMaxBytes = 0xffffffff; // zlib caps maxOutputLength at this value
+
+export function validateReadMaxBytesOption(
+  readMaxBytes: number | undefined
+): number {
+  if (readMaxBytes === undefined) {
+    return maxReadMaxBytes;
+  }
+  if (readMaxBytes < 1 || readMaxBytes > maxReadMaxBytes) {
+    throw new ConnectError(
+      `readMaxBytes ${readMaxBytes} must be >= 1 and <= ${maxReadMaxBytes}`,
+      Code.Internal
+    );
+  }
+  if (readMaxBytes > maxReadMaxBytes) {
+    throw new ConnectError("", Code.Internal);
+  }
+  return readMaxBytes;
+}


### PR DESCRIPTION
This introduces the `Compression` interface, which ties a compression algorithm - for example gzip - to a name.

Handlers will have the following new options:

```ts
  acceptCompression?: Compression[];
  compressMinBytes?: number;
  readMaxBytes?: number;
  sendMaxBytes?: number;
```

By default, handlers accept `gzip` and `brotli` compression.


Clients will have the same new options, but also the following one:

```ts
  sendCompression?: Compression;
```

A client can opt in to request compression by providing one of the exported `compression*` constants (or a custom one). If the client provides `acceptCompression` for a request, the server may choose to use compression in the response.

For the gRPC and the gRCP-web protocol, and for all Connect streaming methods, requests and responses contain a header with the compression name. If the least significant bit of the envelope is set, the data in the envelope is compressed.

For Connect unary methods, the full body is compressed, and the standard `Content-Encoding` header contains the compression name.

Compression is only applied if a serialized message is larger than compressMinBytes.

Note that this PR does not add compression everywhere, only for Connect protocol handlers, and only for Connect http2 clients. That means we still have to implement compression for gRPC and gRPC-web handlers, and for all other Transports.