### PR TITLE
Fix code path for unary in the http2 gRPC transport

### DIFF
--- a/packages/connect-node/src/grpc-http2-transport.ts
+++ b/packages/connect-node/src/grpc-http2-transport.ts
@@ -173,14 +173,14 @@ export function createGrpcHttp2Transport(
             validateResponse(useBinaryFormat, responseCode, responseHeader);
 
             const messageResult = await readEnvelope(stream);
+            const eofResult = await readEnvelope(stream);
+            if (!eofResult.done) {
+              throw "extraneous data";
+            }
             const trailer = await trailerPromise;
             validateGrpcStatus(trailer);
             if (messageResult.done) {
               throw "premature eof";
-            }
-            const eofResult = await readEnvelope(stream);
-            if (!eofResult.done) {
-              throw "extraneous data";
             }
 
             return <UnaryResponse<O>>{


### PR DESCRIPTION
This switches the code path for unary RPCs in the http2 gRPC transport to the code path suggested for the http1 variant in https://github.com/bufbuild/connect-web/pull/367#discussion_r1043410916. This code path passes the tests for both implementations.