### PR TITLE
Make the interceptors argument required in runUnary, runStreaming

### DIFF
--- a/packages/connect-core/src/interceptor.ts
+++ b/packages/connect-core/src/interceptor.ts
@@ -281,7 +281,7 @@ function applyInterceptors<T>(next: T, interceptors: Interceptor[]): T {
 export function runUnary<I extends Message<I>, O extends Message<O>>(
   req: UnaryRequest<I>,
   next: UnaryFn<I, O>,
-  interceptors?: Interceptor[]
+  interceptors: Interceptor[] | undefined
 ): Promise<UnaryResponse<O>> {
   if (interceptors) {
     next = applyInterceptors(next, interceptors);
@@ -296,7 +296,7 @@ export function runUnary<I extends Message<I>, O extends Message<O>>(
 export function runStreaming<I extends Message<I>, O extends Message<O>>(
   req: StreamingRequest<I, O>,
   next: StreamingFn<I, O>,
-  interceptors?: Interceptor[]
+  interceptors: Interceptor[] | undefined
 ): Promise<StreamingConn<I, O>> {
   if (interceptors) {
     next = applyInterceptors(next, interceptors);

--- a/packages/connect-node/src/grpc-web-http-transport.ts
+++ b/packages/connect-node/src/grpc-web-http-transport.ts
@@ -220,7 +220,8 @@ export function createGrpcWebHttpTransport(
               message: parse(messageOrTrailerResult.value.data),
               trailer,
             };
-          }
+          },
+          options.interceptors
         );
       } catch (e) {
         throw connectErrorFromNodeReason(e);
@@ -359,7 +360,8 @@ export function createGrpcWebHttpTransport(
           } catch (e) {
             throw connectErrorFromNodeReason(e);
           }
-        }
+        },
+        options.interceptors
       );
     },
   };


### PR DESCRIPTION
It is too easy to forget to pass interceptors to the functions when implementing a transport. Let's make them required.