### PR TITLE
Make sure that baseUrl stays flexible

### DIFF
--- a/packages/connect-core/src/create-method-url.spec.ts
+++ b/packages/connect-core/src/create-method-url.spec.ts
@@ -25,6 +25,18 @@ describe("createMethodUrl()", function () {
       "https://example.com/example.Service/Method"
     );
   });
+  it("should accept empty string as baseUrl", function () {
+    const url = createMethodUrl("", "example.Service", "Method");
+    expect(url.toString()).toEqual("/example.Service/Method");
+  });
+  it("should accept '/' as baseUrl", function () {
+    const url = createMethodUrl("/", "example.Service", "Method");
+    expect(url.toString()).toEqual("/example.Service/Method");
+  });
+  it("should handle protocol-relative baseUrl", function () {
+    const url = createMethodUrl("//example.com", "example.Service", "Method");
+    expect(url.toString()).toEqual("//example.com/example.Service/Method");
+  });
   it("should not duplicating slashes", function () {
     const url = createMethodUrl(
       "https://example.com/",

--- a/packages/connect-core/src/create-method-url.ts
+++ b/packages/connect-core/src/create-method-url.ts
@@ -16,15 +16,25 @@ import type { MethodInfo, ServiceType } from "@bufbuild/protobuf";
 
 /**
  * Create a URL for the given RPC. This simply adds the qualified
- * service name, a slash, and the method name to the path.
+ * service name, a slash, and the method name to the path of the given
+ * baseUrl.
+ *
+ * For example, the baseUri https://example.com and method "Say" from
+ * the service example.ElizaService results in:
+ * https://example.com/example.ElizaService/Say
+ *
  * This format is used by the protocols Connect, gRPC and Twirp.
+ *
+ * Note that this function also accepts a protocol-relative baseUrl.
+ * If given an empty string or "/" as a baseUrl, it returns just the
+ * path.
  */
 export function createMethodUrl(
   baseUrl: string | URL,
   service: ServiceType | string,
   method: MethodInfo | string
-): URL {
+): string {
   const s = typeof service == "string" ? service : service.typeName;
   const m = typeof method == "string" ? method : method.name;
-  return new URL(baseUrl.toString().replace(/\/?$/, `/${s}/${m}`));
+  return baseUrl.toString().replace(/\/?$/, `/${s}/${m}`);
 }

--- a/packages/connect-node/src/connect-http-transport.ts
+++ b/packages/connect-node/src/connect-http-transport.ts
@@ -157,7 +157,7 @@ export function createConnectHttpTransport(
             stream: false,
             service,
             method,
-            url: createMethodUrl(options.baseUrl, service, method).toString(),
+            url: createMethodUrl(options.baseUrl, service, method),
             init: {},
             header: createRequestHeader(timeoutMs, header),
             message: normalize(message),
@@ -233,7 +233,7 @@ export function createConnectHttpTransport(
           stream: true,
           service,
           method,
-          url: createMethodUrl(options.baseUrl, service, method).toString(),
+          url: createMethodUrl(options.baseUrl, service, method),
           init: {
             method: "POST",
             redirect: "error",

--- a/packages/connect-node/src/connect-http2-transport.ts
+++ b/packages/connect-node/src/connect-http2-transport.ts
@@ -159,7 +159,7 @@ export function createConnectHttp2Transport(
             stream: false,
             service,
             method,
-            url: createMethodUrl(options.baseUrl, service, method).toString(),
+            url: createMethodUrl(options.baseUrl, service, method),
             init: {},
             header: connectCreateRequestHeaderWithCompression(
               method.kind,
@@ -273,7 +273,7 @@ export function createConnectHttp2Transport(
           stream: true,
           service,
           method,
-          url: createMethodUrl(options.baseUrl, service, method).toString(),
+          url: createMethodUrl(options.baseUrl, service, method),
           init: {
             method: "POST",
             redirect: "error",

--- a/packages/connect-node/src/grpc-http-transport.ts
+++ b/packages/connect-node/src/grpc-http-transport.ts
@@ -146,7 +146,7 @@ export function createGrpcHttpTransport(
             stream: false,
             service,
             method,
-            url: createMethodUrl(options.baseUrl, service, method).toString(),
+            url: createMethodUrl(options.baseUrl, service, method),
             init: {},
             header: grpcCreateRequestHeader(useBinaryFormat, timeoutMs, header),
             message: normalize(message),
@@ -228,7 +228,7 @@ export function createGrpcHttpTransport(
           stream: true,
           service,
           method,
-          url: createMethodUrl(options.baseUrl, service, method).toString(),
+          url: createMethodUrl(options.baseUrl, service, method),
           init: {
             method: "POST",
             redirect: "error",

--- a/packages/connect-node/src/grpc-http2-transport.ts
+++ b/packages/connect-node/src/grpc-http2-transport.ts
@@ -129,7 +129,7 @@ export function createGrpcHttp2Transport(
             stream: false,
             service,
             method,
-            url: createMethodUrl(options.baseUrl, service, method).toString(),
+            url: createMethodUrl(options.baseUrl, service, method),
             init: {},
             header: grpcCreateRequestHeader(useBinaryFormat, timeoutMs, header),
             message: normalize(message),
@@ -217,7 +217,7 @@ export function createGrpcHttp2Transport(
           stream: true,
           service,
           method,
-          url: createMethodUrl(options.baseUrl, service, method).toString(),
+          url: createMethodUrl(options.baseUrl, service, method),
           init: {
             method: "POST",
             redirect: "error",

--- a/packages/connect-node/src/grpc-web-http-transport.ts
+++ b/packages/connect-node/src/grpc-web-http-transport.ts
@@ -141,7 +141,7 @@ export function createGrpcWebHttpTransport(
             stream: false,
             service,
             method,
-            url: createMethodUrl(options.baseUrl, service, method).toString(),
+            url: createMethodUrl(options.baseUrl, service, method),
             init: {},
             header: grpcWebCreateRequestHeader(
               useBinaryFormat,
@@ -242,7 +242,7 @@ export function createGrpcWebHttpTransport(
           stream: true,
           service,
           method,
-          url: createMethodUrl(options.baseUrl, service, method).toString(),
+          url: createMethodUrl(options.baseUrl, service, method),
           init: {
             method: "POST",
             redirect: "error",

--- a/packages/connect-node/src/grpc-web-http2-transport.ts
+++ b/packages/connect-node/src/grpc-web-http2-transport.ts
@@ -124,7 +124,7 @@ export function createGrpcWebHttp2Transport(
             stream: false,
             service,
             method,
-            url: createMethodUrl(options.baseUrl, service, method).toString(),
+            url: createMethodUrl(options.baseUrl, service, method),
             init: {},
             header: grpcWebCreateRequestHeader(
               useBinaryFormat,
@@ -240,7 +240,7 @@ export function createGrpcWebHttp2Transport(
           stream: true,
           service,
           method,
-          url: createMethodUrl(options.baseUrl, service, method).toString(),
+          url: createMethodUrl(options.baseUrl, service, method),
           init: {
             method: "POST",
             redirect: "error",

--- a/packages/connect-node/src/handler.ts
+++ b/packages/connect-node/src/handler.ts
@@ -126,8 +126,7 @@ export function createHandler<M extends MethodInfo>(
   return Object.assign(handleAny, {
     service,
     method,
-    requestPath: createMethodUrl("https://example.com", service, method)
-      .pathname,
+    requestPath: createMethodUrl("/", service, method),
   });
 }
 

--- a/packages/connect-web-bench/README.md
+++ b/packages/connect-web-bench/README.md
@@ -10,6 +10,6 @@ it like a web server would usually do.
 
 | code generator | bundle size        | minified               | compressed           |
 |----------------|-------------------:|-----------------------:|---------------------:|
-| connect-web    | 93,342 b | 43,118 b | 11,896 b |
+| connect-web    | 93,311 b | 43,087 b | 11,880 b |
 | connect-web (legacy) | 88,075 b | 41,044 b | 11,381 b |
 | grpc-web       | 413,539 b    | 301,008 b    | 53,234 b |

--- a/packages/connect-web-next/src/connect-transport.ts
+++ b/packages/connect-web-next/src/connect-transport.ts
@@ -69,6 +69,9 @@ export interface ConnectTransportOptions {
    *
    * This will make a `POST /my-api/my_package.MyService/Foo` to
    * `example.com` via HTTPS.
+   *
+   * If your API is served from the same domain as your site, use
+   * `baseUrl: window.location.origin` or simply "/".
    */
   baseUrl: string;
 
@@ -140,7 +143,7 @@ export function createConnectTransport(
             stream: false,
             service,
             method,
-            url: createMethodUrl(options.baseUrl, service, method).toString(),
+            url: createMethodUrl(options.baseUrl, service, method),
             init: {
               method: "POST",
               credentials: options.credentials ?? "same-origin",
@@ -215,7 +218,7 @@ export function createConnectTransport(
           stream: true,
           service,
           method,
-          url: createMethodUrl(options.baseUrl, service, method).toString(),
+          url: createMethodUrl(options.baseUrl, service, method),
           init: {
             method: "POST",
             credentials: options.credentials ?? "same-origin",

--- a/packages/connect-web-next/src/grpc-web-transport.ts
+++ b/packages/connect-web-next/src/grpc-web-transport.ts
@@ -66,6 +66,9 @@ export interface GrpcWebTransportOptions {
    *
    * This will make a `POST /my-api/my_package.MyService/Foo` to
    * `example.com` via HTTPS.
+   *
+   * If your API is served from the same domain as your site, use
+   * `baseUrl: window.location.origin` or simply "/".
    */
   baseUrl: string;
 
@@ -138,7 +141,7 @@ export function createGrpcWebTransport(
             stream: false,
             service,
             method,
-            url: createMethodUrl(options.baseUrl, service, method).toString(),
+            url: createMethodUrl(options.baseUrl, service, method),
             init: {
               method: "POST",
               credentials: options.credentials ?? "same-origin",
@@ -235,7 +238,7 @@ export function createGrpcWebTransport(
           stream: true,
           service,
           method,
-          url: createMethodUrl(options.baseUrl, service, method).toString(),
+          url: createMethodUrl(options.baseUrl, service, method),
           init: {
             method: "POST",
             credentials: options.credentials ?? "same-origin",


### PR DESCRIPTION
I noticed that some users don't use full baseUrls, for example:

```ts
createConnectTransport({
  baseUrl: "/"
})
```

This is valid and useful in a web application. We switched to `URL` in @bufbuild/connect-core, which requires a scheme and host, so we would break existing use cases. 

This reverts this (unreleased) change - `createMethodUrl()` now returns a string.