### PR TITLE
remove Converse method from generated code

### DIFF
--- a/packages/protoc-gen-connect-web/README.md
+++ b/packages/protoc-gen-connect-web/README.md
@@ -175,18 +175,6 @@ export const ElizaService = {
       O: SayResponse,
       kind: MethodKind.Unary,
     },
-    /**
-     * Converse is a bi-directional request demo. This method should allow for
-     * many requests and many responses.
-     *
-     * @generated from rpc buf.connect.demo.eliza.v1.ElizaService.Converse
-     */
-    converse: {
-      name: "Converse",
-      I: ConverseRequest,
-      O: ConverseResponse,
-      kind: MethodKind.BiDiStreaming,
-    },
   }
 } as const;
 ```


### PR DESCRIPTION
In the README, we include a stripped down version of eliza.proto which only includes the Say method. We should remove the Converse method from the generated code so it matches the example proto.