### PR TITLE
Removes deprecated ConnectError constructor

### DIFF
--- a/packages/connect-web-bench/README.md
+++ b/packages/connect-web-bench/README.md
@@ -10,6 +10,6 @@ it like a web server would usually do.
 
 | code generator | bundle size        | minified               | compressed           |
 |----------------|-------------------:|-----------------------:|---------------------:|
-| connect-web    | 101,457 b | 43,331 b | 11,940 b |
-| connect-web (legacy) | 94,981 b | 41,061 b | 11,392 b |
+| connect-web    | 101,543 b | 43,379 b | 11,930 b |
+| connect-web (legacy) | 94,850 b | 40,976 b | 11,358 b |
 | grpc-web       | 414,073 b    | 301,006 b    | 53,260 b |

--- a/packages/connect-web-test/src/legacy-connect-error.spec.ts
+++ b/packages/connect-web-test/src/legacy-connect-error.spec.ts
@@ -47,13 +47,6 @@ describe("ConnectError", () => {
       expect(e.rawMessage).toBe("foo");
       expect(String(e)).toBe("ConnectError: [already_exists] foo");
     });
-    it("accepts details but ignores them in the deprecated constructor", () => {
-      const e = new ConnectError("foo", Code.AlreadyExists, [new Struct()], {
-        foo: "bar",
-      });
-      expect(e.details).toEqual([]);
-      expect(e.metadata.get("foo")).toBe("bar");
-    });
     it("accepts metadata", () => {
       const e = new ConnectError("foo", Code.AlreadyExists, { foo: "bar" });
       expect(e.metadata.get("foo")).toBe("bar");

--- a/packages/connect-web/src/connect-error.ts
+++ b/packages/connect-web/src/connect-error.ts
@@ -69,22 +69,9 @@ export class ConnectError extends Error {
    * Create a new ConnectError. If no code is provided, code "unknown" is
    * used.
    */
-  constructor(message: string, code?: Code, metadata?: HeadersInit);
-  /**
-   * @deprecated We do not support providing error details in the constructor.
-   * This signature was left here by accident, and will be removed in the next
-   * release.
-   */
-  constructor(
-    message: string,
-    code?: Code,
-    details?: AnyMessage[],
-    metadata?: HeadersInit
-  );
   constructor(
     message: string,
     code: Code = Code.Unknown,
-    detailsOrMetadata?: AnyMessage[] | HeadersInit,
     metadata?: HeadersInit
   ) {
     super(createMessage(message, code));
@@ -92,12 +79,7 @@ export class ConnectError extends Error {
     Object.setPrototypeOf(this, new.target.prototype);
     this.rawMessage = message;
     this.code = code;
-    // TODO once we remove the deprecated constructor, this can become `new Headers(metadata ?? {})`
-    const metadataInit =
-      metadata ??
-      (Array.isArray(detailsOrMetadata) ? undefined : detailsOrMetadata) ??
-      {};
-    this.metadata = new Headers(metadataInit);
+    this.metadata = new Headers(metadata);
     this.details = [];
   }
 }
@@ -185,7 +167,7 @@ export function connectErrorFromJson(
   if (message != null && typeof message !== "string") {
     throw newParseError(jsonValue.code, ".message");
   }
-  const error = new ConnectError(message ?? "", code, undefined, metadata);
+  const error = new ConnectError(message ?? "", code, metadata);
   if ("details" in jsonValue && Array.isArray(jsonValue.details)) {
     for (const detail of jsonValue.details) {
       if (

--- a/packages/connect-web/src/grpc-web-transport.ts
+++ b/packages/connect-web/src/grpc-web-transport.ts
@@ -384,14 +384,12 @@ function extractHeadersError(header: Headers): ConnectError | undefined {
     return new ConnectError(
       `invalid grpc-status: ${value}`,
       Code.Internal,
-      undefined,
       header
     );
   }
   return new ConnectError(
     decodeURIComponent(header.get("grpc-message") ?? ""),
     code,
-    undefined,
     header
   );
 }
@@ -407,12 +405,7 @@ function extractDetailsError(header: Headers): ConnectError | undefined {
     if (status.code == 0) {
       return undefined;
     }
-    const error = new ConnectError(
-      status.message,
-      status.code,
-      undefined,
-      header
-    );
+    const error = new ConnectError(status.message, status.code, header);
     error.details.push(...status.details);
     return error;
   } catch (e) {


### PR DESCRIPTION
This removes the previously-deprecated ConnectError constructor which accepts details as a parameter.

Note:  this is a breaking change and should be called out in the release notes when released.