### PR TITLE
Add WHATWG transform streams

### DIFF
--- a/packages/connect-core/src/compression.ts
+++ b/packages/connect-core/src/compression.ts
@@ -1,0 +1,44 @@
+// Copyright 2021-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * compressedFlag indicates that the data in a EnvelopedMessage is
+ * compressed. It has the same meaning in the gRPC-Web, gRPC-HTTP2,
+ * and Connect protocols.
+ */
+export const compressedFlag = 0b00000001;
+
+/**
+ * Compression provides methods to compress and decompress data with
+ * a certain compression algorithm.
+ */
+export interface Compression {
+  /**
+   * The name of the compression algorithm.
+   */
+  name: string;
+
+  /**
+   * Compress a chunk of data.
+   */
+  compress: (bytes: Uint8Array) => Promise<Uint8Array>;
+
+  /**
+   * Decompress a chunk of data.
+   *
+   * Raises a ConnectError with Code.InvalidArgument if the decompressed
+   * size exceeds readMaxBytes.
+   */
+  decompress: (bytes: Uint8Array, readMaxBytes: number) => Promise<Uint8Array>;
+}

--- a/packages/connect-core/src/envelope.ts
+++ b/packages/connect-core/src/envelope.ts
@@ -32,10 +32,13 @@ export interface EnvelopedMessage {
 }
 
 /**
- * Create a ReadableStream of enveloped messages from a ReadableStream of bytes.
+ * Create a WHATWG ReadableStream of enveloped messages from a ReadableStream
+ * of bytes.
  *
  * Ideally, this would simply be a TransformStream, but ReadableStream.pipeThrough
  * does not have the necessary availability at this time.
+ *
+ * Note that such a TransformStream is implement by transformSplit().
  */
 export function createEnvelopeReadableStream(
   stream: ReadableStream<Uint8Array>

--- a/packages/connect-core/src/index.ts
+++ b/packages/connect-core/src/index.ts
@@ -53,3 +53,14 @@ export {
   encodeEnvelope,
   encodeEnvelopes,
 } from "./envelope.js";
+export { Compression, compressedFlag } from "./compression.js";
+export {
+  transformCompress,
+  transformDecompress,
+  transformJoin,
+  transformSplit,
+  transformSerialize,
+  transformParse,
+  transformSerializeWithEnd,
+  transformParseWithEnd,
+} from "./transform-stream.js";

--- a/packages/connect-core/src/transform-stream-story.spec.ts
+++ b/packages/connect-core/src/transform-stream-story.spec.ts
@@ -1,0 +1,324 @@
+// Copyright 2021-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  createReadableByteStream,
+  createReadableStream,
+  node16WhatwgStreamPolyfill,
+  readAll,
+  readAllBytes,
+} from "./whatwg-stream-helper.spec.js";
+import type { Serialization } from "./serialization.js";
+import {
+  transformCompress,
+  transformDecompress,
+  transformJoin,
+  transformParseWithEnd,
+  transformSerializeWithEnd,
+  transformSplit,
+} from "./transform-stream.js";
+import type { Compression } from "./compression.js";
+import { encodeEnvelopes } from "./envelope.js";
+import { ConnectError } from "./connect-error.js";
+import { Code } from "./code.js";
+
+node16WhatwgStreamPolyfill();
+
+// These tests aim to model the usage of transform streams in clients and servers.
+// Note that the tests were written as a proof of concept, and the coverage is
+// incomplete (cancellation, backpressure, error handling, etc.).
+describe("full story", function () {
+  const readMaxBytes = 0xffffffff; // zlib caps maxOutputLength at this value
+  const writeMaxBytes = readMaxBytes;
+  const serialization: Serialization<string> = {
+    serialize(data: string): Uint8Array {
+      return new TextEncoder().encode(data);
+    },
+    parse(data: Uint8Array): string {
+      return new TextDecoder().decode(data);
+    },
+  };
+  const endSerialization: Serialization<"end"> = {
+    serialize(data: string): Uint8Array {
+      return new TextEncoder().encode(data + ".");
+    },
+    parse(data: Uint8Array): "end" {
+      const t = new TextDecoder().decode(data).slice(0, -1);
+      if (t !== "end") {
+        throw new ConnectError(
+          "serialize end: cannot parse",
+          Code.InvalidArgument
+        );
+      }
+      return t;
+    },
+  };
+  const endFlag = 0b10000000;
+  const compressionReverse: Compression = {
+    name: "fake",
+    compress(bytes) {
+      const b = new Uint8Array(bytes.byteLength);
+      b.set(bytes, 0);
+      return Promise.resolve(b.reverse());
+    },
+    decompress(bytes, readMaxBytes) {
+      if (bytes.byteLength > readMaxBytes) {
+        return Promise.reject(
+          new ConnectError(
+            `message is larger than configured readMaxBytes ${readMaxBytes} after decompression`,
+            Code.ResourceExhausted
+          )
+        );
+      }
+      const b = new Uint8Array(bytes.byteLength);
+      b.set(bytes, 0);
+      return Promise.resolve(b.reverse());
+    },
+  };
+  const goldenBytes = encodeEnvelopes(
+    {
+      flags: 0 | 0b00000001,
+      data: new TextEncoder().encode("alpha").reverse(),
+    },
+    {
+      flags: 0 | 0b00000001,
+      data: new TextEncoder().encode("beta").reverse(),
+    },
+    {
+      flags: 0 | 0b00000001 | endFlag,
+      data: new TextEncoder().encode("end.").reverse(),
+    }
+  );
+  type Payload<I, E> = { end: false; value: I } | { end: true; value: E };
+  const goldenPayload: Payload<string, "end">[] = [
+    { value: "alpha", end: false },
+    { value: "beta", end: false },
+    { value: "end", end: true },
+  ];
+
+  describe("write", function () {
+    it("should write expected bytes", async function () {
+      const stream = createReadableStream(goldenPayload)
+        .pipeThrough(
+          transformSerializeWithEnd(serialization, endSerialization, endFlag),
+          {}
+        )
+        .pipeThrough(
+          transformCompress(compressionReverse, writeMaxBytes, 0),
+          {}
+        )
+        .pipeThrough(transformJoin(writeMaxBytes), {});
+      const all = await readAllBytes(stream);
+      expect(all).toEqual(goldenBytes);
+    });
+  });
+
+  describe("read", function () {
+    it("should read expected bytes", async function () {
+      const inputStream = createReadableByteStream(goldenBytes)
+        .pipeThrough(transformSplit(readMaxBytes), {})
+        .pipeThrough(transformDecompress(compressionReverse, readMaxBytes), {})
+        .pipeThrough(
+          transformParseWithEnd(serialization, endSerialization, endFlag),
+          {}
+        );
+      const all = await readAll(inputStream);
+      expect(all).toEqual(goldenPayload);
+    });
+  });
+
+  describe("client integration", function () {
+    it("should works", async function () {
+      const requestTransformStream = new TransformStream<
+        { end: false; value: string } | { end: true; value: "end" },
+        { end: false; value: string } | { end: true; value: "end" }
+      >();
+      const requestWriter = requestTransformStream.writable.getWriter();
+      const rawRequestStream = requestTransformStream.readable
+        .pipeThrough(
+          transformSerializeWithEnd(serialization, endSerialization, endFlag),
+          {}
+        )
+        .pipeThrough(
+          transformCompress(compressionReverse, writeMaxBytes, 0),
+          {}
+        )
+        .pipeThrough(transformJoin(writeMaxBytes), {});
+
+      const responseReader = createReadableByteStream(goldenBytes)
+        .pipeThrough(transformSplit(readMaxBytes), {})
+        .pipeThrough(transformDecompress(compressionReverse, readMaxBytes), {})
+        .pipeThrough(
+          transformParseWithEnd(serialization, endSerialization, endFlag),
+          {}
+        )
+        .getReader();
+
+      const streamingConn = {
+        async send(message: string): Promise<void> {
+          await requestWriter.ready;
+          await requestWriter.write({
+            end: false,
+            value: message,
+          });
+        },
+        async close(): Promise<void> {
+          await requestWriter.ready;
+          await requestWriter.write({
+            end: true,
+            value: "end",
+          });
+          await requestWriter.close();
+        },
+        async read(): Promise<ReadableStreamReadResult<string>> {
+          const r = await responseReader.read();
+          if (r.done) {
+            return {
+              done: true,
+              value: undefined,
+            };
+          }
+          if (r.value.end) {
+            return {
+              done: true,
+              value: undefined,
+            };
+          }
+          return {
+            done: false,
+            value: r.value.value,
+          };
+        },
+      };
+
+      const writtenBytesPromise = readAllBytes(rawRequestStream);
+
+      await streamingConn.send("alpha");
+      await streamingConn.send("beta");
+      await streamingConn.close();
+
+      const alpha = await streamingConn.read();
+      expect(alpha).toEqual({
+        done: false,
+        value: "alpha",
+      });
+      const beta = await streamingConn.read();
+      expect(beta).toEqual({
+        done: false,
+        value: "beta",
+      });
+      const end = await streamingConn.read();
+      expect(end).toEqual({
+        done: true,
+        value: undefined,
+      });
+
+      const writtenBytes = await writtenBytesPromise;
+      expect(writtenBytes).toEqual(goldenBytes);
+    });
+  });
+
+  describe("server integration", function () {
+    const echoImplReceived: string[] = [];
+
+    async function* echoImpl(
+      input: AsyncIterable<string>
+    ): AsyncIterable<string> {
+      for await (const i of input) {
+        echoImplReceived.push(i);
+        yield i;
+      }
+    }
+
+    beforeEach(function () {
+      echoImplReceived.splice(0);
+    });
+
+    it("should echo expected bytes", async function () {
+      const requestStream = createReadableByteStream(goldenBytes)
+        .pipeThrough(transformSplit(readMaxBytes), {})
+        .pipeThrough(transformDecompress(compressionReverse, readMaxBytes), {})
+        .pipeThrough(
+          transformParseWithEnd(serialization, endSerialization, endFlag),
+          {}
+        );
+
+      // implementations take an iterable - make our stream available as one
+      const implInput: AsyncIterable<string> = {
+        [Symbol.asyncIterator](): AsyncIterator<string> {
+          const reader = requestStream.getReader();
+          return {
+            async next(): Promise<IteratorResult<string>> {
+              const r = await reader.read();
+              if (r.done) {
+                return {
+                  done: true,
+                  value: undefined,
+                };
+              }
+              if (r.value.end) {
+                return {
+                  done: true,
+                  value: undefined,
+                };
+              }
+              return {
+                done: false,
+                value: r.value.value,
+              };
+            },
+          };
+        },
+      };
+
+      // invoke the implementation
+      const implOutput = echoImpl(implInput)[Symbol.asyncIterator]();
+
+      // implementations return an iterable - make a readable stream from it
+      const responseStream = new ReadableStream<
+        { end: false; value: string } | { end: true; value: string }
+      >({
+        async pull(controller) {
+          const r = await implOutput.next();
+          if (r.done === true) {
+            controller.enqueue({
+              end: true,
+              value: "end",
+            });
+            return controller.close();
+          }
+          controller.enqueue({
+            end: false,
+            value: r.value,
+          });
+        },
+      })
+        .pipeThrough(
+          transformSerializeWithEnd(serialization, endSerialization, endFlag),
+          {}
+        )
+        .pipeThrough(
+          transformCompress(compressionReverse, writeMaxBytes, 0),
+          {}
+        )
+        .pipeThrough(transformJoin(writeMaxBytes), {});
+
+      // in practice, we would pipe the response data to a writable stream with pipeTo()
+      expect(await readAllBytes(responseStream)).toEqual(goldenBytes);
+
+      // sanity check that the implementation was invoked
+      expect(echoImplReceived).toEqual(["alpha", "beta"]);
+    });
+  });
+});

--- a/packages/connect-core/src/transform-stream.spec.ts
+++ b/packages/connect-core/src/transform-stream.spec.ts
@@ -1,0 +1,436 @@
+// Copyright 2021-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  transformCompress,
+  transformDecompress,
+  transformJoin,
+  transformParse,
+  transformParseWithEnd,
+  transformSerialize,
+  transformSerializeWithEnd,
+  transformSplit,
+} from "./transform-stream.js";
+import type { Compression } from "./compression.js";
+import type { Serialization } from "./serialization.js";
+import type { EnvelopedMessage } from "./envelope.js";
+import { ConnectError, connectErrorFromReason } from "./connect-error.js";
+import { Code } from "./code.js";
+import {
+  createReadableByteStream,
+  createReadableStream,
+  node16WhatwgStreamPolyfill,
+  readAll,
+  readAllBytes,
+} from "./whatwg-stream-helper.spec.js";
+
+node16WhatwgStreamPolyfill();
+
+describe("transforming WHATWG streams", () => {
+  describe("serialization", function () {
+    const goldenItems = ["a", "b", "c"];
+    const goldenEnvelopes = [
+      {
+        data: new TextEncoder().encode("a"),
+        flags: 0b00000000,
+      },
+      {
+        data: new TextEncoder().encode("b"),
+        flags: 0b00000000,
+      },
+      {
+        data: new TextEncoder().encode("c"),
+        flags: 0b00000000,
+      },
+    ];
+    const fakeSerialization: Serialization<string> = {
+      serialize(data: string): Uint8Array {
+        return new TextEncoder().encode(data);
+      },
+      parse(data: Uint8Array): string {
+        return new TextDecoder().decode(data);
+      },
+    };
+    describe("transformSerialize()", function () {
+      it("should serialize to envelopes", async function () {
+        const stream = createReadableStream(goldenItems).pipeThrough(
+          transformSerialize(fakeSerialization),
+          {}
+        );
+        const got = await readAll(stream);
+        expect(got).toEqual(goldenEnvelopes);
+      });
+    });
+    describe("transformParse()", function () {
+      it("should parse from envelopes", async function () {
+        const stream = createReadableStream(goldenEnvelopes).pipeThrough(
+          transformParse(fakeSerialization),
+          {}
+        );
+        const got = await readAll(stream);
+        expect(got).toEqual(goldenItems);
+      });
+    });
+  });
+
+  describe("serialization with end", function () {
+    const endFlag = 0b10000000;
+    const goldenItems = [
+      { value: "a", end: false },
+      { value: "b", end: false },
+      { value: "end", end: true },
+    ];
+    const goldenEnvelopes = [
+      {
+        data: new TextEncoder().encode("a"),
+        flags: 0b00000000,
+      },
+      {
+        data: new TextEncoder().encode("b"),
+        flags: 0b00000000,
+      },
+      {
+        data: new TextEncoder().encode("end."),
+        flags: endFlag,
+      },
+    ];
+    const serialization: Serialization<string> = {
+      serialize(data: string): Uint8Array {
+        return new TextEncoder().encode(data);
+      },
+      parse(data: Uint8Array): string {
+        return new TextDecoder().decode(data);
+      },
+    };
+    const endSerialization: Serialization<string> = {
+      serialize(data: string): Uint8Array {
+        return new TextEncoder().encode(data + ".");
+      },
+      parse(data: Uint8Array): string {
+        return new TextDecoder().decode(data).slice(0, -1);
+      },
+    };
+
+    describe("transformSerializeWithEnd()", function () {
+      it("should serialize to envelopes", async function () {
+        const stream = createReadableStream(goldenItems).pipeThrough(
+          transformSerializeWithEnd(serialization, endSerialization, endFlag),
+          {}
+        );
+        const got = await readAll(stream);
+        expect(got).toEqual(goldenEnvelopes);
+      });
+    });
+
+    describe("transformParseWithEnd()", function () {
+      it("should parse from envelopes", async function () {
+        const stream = createReadableStream(goldenEnvelopes).pipeThrough(
+          transformParseWithEnd(serialization, endSerialization, endFlag),
+          {}
+        );
+        const got = await readAll(stream);
+        expect(got).toEqual(goldenItems);
+      });
+    });
+  });
+
+  describe("joining and splitting envelopes", function () {
+    const goldenEnvelopes: EnvelopedMessage[] = [
+      {
+        data: new Uint8Array([0xde, 0xad, 0xbe, 0xef]),
+        flags: 0b00000000,
+      },
+      {
+        data: new Uint8Array([0xde, 0xad, 0xbe, 0xe0]),
+        flags: 0b00000000,
+      },
+      {
+        data: new Uint8Array([0xde, 0xad, 0xbe, 0xe1]),
+        flags: 0b10000000,
+      },
+    ];
+    const goldenBytes = new Uint8Array([
+      0x0, 0x0, 0x0, 0x0, 0x4, 0xde, 0xad, 0xbe, 0xef, 0x0, 0x0, 0x0, 0x0, 0x4,
+      0xde, 0xad, 0xbe, 0xe0, 0x80, 0x0, 0x0, 0x0, 0x4, 0xde, 0xad, 0xbe, 0xe1,
+    ]);
+
+    describe("transformJoin()", function () {
+      it("should join envelopes", async function () {
+        const stream = createReadableStream(goldenEnvelopes).pipeThrough(
+          transformJoin(Number.MAX_SAFE_INTEGER),
+          {}
+        );
+        const gotBytes = await readAllBytes(stream);
+        expect(gotBytes).toEqual(goldenBytes);
+      });
+      it("should honor writeMaxBytes", async function () {
+        const stream = createReadableStream(goldenEnvelopes).pipeThrough(
+          transformJoin(3),
+          {}
+        );
+        try {
+          await readAll(stream);
+          fail("expected error");
+        } catch (e) {
+          expect(e).toBeInstanceOf(ConnectError);
+          expect(connectErrorFromReason(e).message).toBe(
+            "[resource_exhausted] message size 4 is larger than configured writeMaxBytes 3"
+          );
+        }
+      });
+    });
+
+    describe("transformSplit()", function () {
+      it("should split envelopes", async function () {
+        const stream = createReadableByteStream(goldenBytes).pipeThrough(
+          transformSplit(Number.MAX_SAFE_INTEGER),
+          {}
+        );
+        const got = await readAll(stream);
+        expect(got).toEqual(goldenEnvelopes);
+      });
+      it("should honor readMaxBytes", async function () {
+        const stream = createReadableByteStream(goldenBytes).pipeThrough(
+          transformSplit(3),
+          {}
+        );
+        try {
+          await readAll(stream);
+          fail("expected error");
+        } catch (e) {
+          expect(e).toBeInstanceOf(ConnectError);
+          expect(connectErrorFromReason(e).message).toBe(
+            "[resource_exhausted] message size 4 is larger than configured readMaxBytes 3"
+          );
+        }
+      });
+    });
+  });
+
+  describe("(de-)compressing envelopes", function () {
+    const uncompressedEnvelopes: EnvelopedMessage[] = [
+      {
+        data: new Uint8Array([0xde, 0xad, 0xbe, 0xef]),
+        flags: 0b00000000,
+      },
+      {
+        data: new Uint8Array([0xde, 0xad, 0xbe, 0xe0]),
+        flags: 0b00000000,
+      },
+      {
+        data: new Uint8Array([0xde, 0xad, 0xbe, 0xe1]),
+        flags: 0b10000000,
+      },
+    ];
+    const compressedEnvelopes: EnvelopedMessage[] = [
+      {
+        data: new Uint8Array([0xde, 0xad, 0xbe, 0xef].reverse()),
+        flags: 0b00000001,
+      },
+      {
+        data: new Uint8Array([0xde, 0xad, 0xbe, 0xe0].reverse()),
+        flags: 0b00000001,
+      },
+      {
+        data: new Uint8Array([0xde, 0xad, 0xbe, 0xe1].reverse()),
+        flags: 0b10000001,
+      },
+    ];
+    const compressionReverse: Compression = {
+      name: "fake",
+      compress(bytes) {
+        const b = new Uint8Array(bytes.byteLength);
+        b.set(bytes, 0);
+        return Promise.resolve(b.reverse());
+      },
+      decompress(bytes, readMaxBytes) {
+        if (bytes.byteLength > readMaxBytes) {
+          return Promise.reject(
+            new ConnectError(
+              `message is larger than configured readMaxBytes ${readMaxBytes} after decompression`,
+              Code.ResourceExhausted
+            )
+          );
+        }
+        const b = new Uint8Array(bytes.byteLength);
+        b.set(bytes, 0);
+        return Promise.resolve(b.reverse());
+      },
+    };
+
+    describe("transformCompress()", function () {
+      it("should compress envelopes", async function () {
+        const stream = createReadableStream(uncompressedEnvelopes).pipeThrough(
+          transformCompress(compressionReverse, Number.MAX_SAFE_INTEGER, 0),
+          {}
+        );
+        const gotEnvelopes = await readAll(stream);
+        expect(gotEnvelopes).toEqual(compressedEnvelopes);
+      });
+      it("should throw on compressed input", async function () {
+        const stream = createReadableStream(compressedEnvelopes).pipeThrough(
+          transformCompress(compressionReverse, 3, 0),
+          {}
+        );
+        try {
+          await readAll(stream);
+          fail("expected error");
+        } catch (e) {
+          expect(e).toBeInstanceOf(ConnectError);
+          expect(connectErrorFromReason(e).message).toBe(
+            "[internal] invalid envelope, already compressed"
+          );
+        }
+      });
+      it("should honor compressMinBytes", async function () {
+        const stream = createReadableStream(uncompressedEnvelopes).pipeThrough(
+          transformCompress(compressionReverse, Number.MAX_SAFE_INTEGER, 5),
+          {}
+        );
+        const gotEnvelopes = await readAll(stream);
+        expect(gotEnvelopes).toEqual(uncompressedEnvelopes);
+      });
+      it("should honor writeMaxBytes for the compressed message", async function () {
+        const compressionTo5Bytes: Compression = {
+          name: "fake",
+          compress(bytes) {
+            const b = new Uint8Array(5);
+            b.set(bytes, 0);
+            return Promise.resolve(b);
+          },
+          decompress() {
+            throw "unimplemented";
+          },
+        };
+        const stream = createReadableStream(uncompressedEnvelopes).pipeThrough(
+          transformCompress(compressionTo5Bytes, 4, 0),
+          {}
+        );
+        try {
+          await readAll(stream);
+          fail("expected error");
+        } catch (e) {
+          expect(e).toBeInstanceOf(ConnectError);
+          expect(connectErrorFromReason(e).message).toBe(
+            "[resource_exhausted] message size 5 is larger than configured writeMaxBytes 4"
+          );
+        }
+      });
+    });
+
+    describe("transformDecompress()", function () {
+      it("should decompress envelopes", async function () {
+        const stream = createReadableStream(compressedEnvelopes).pipeThrough(
+          transformDecompress(compressionReverse, Number.MAX_SAFE_INTEGER),
+          {}
+        );
+        const gotEnvelopes = await readAll(stream);
+        expect(gotEnvelopes).toEqual(uncompressedEnvelopes);
+      });
+      it("should not decompress uncompressed envelopes", async function () {
+        const stream = createReadableStream(uncompressedEnvelopes).pipeThrough(
+          transformDecompress(compressionReverse, Number.MAX_SAFE_INTEGER),
+          {}
+        );
+        const gotEnvelopes = await readAll(stream);
+        expect(gotEnvelopes).toEqual(uncompressedEnvelopes);
+      });
+      it("should pass readMaxBytes to compression", async function () {
+        const stream = createReadableStream(compressedEnvelopes).pipeThrough(
+          transformDecompress(compressionReverse, 3),
+          {}
+        );
+        try {
+          await readAll(stream);
+          fail("expected error");
+        } catch (e) {
+          expect(e).toBeInstanceOf(ConnectError);
+          expect(connectErrorFromReason(e).message).toBe(
+            "[resource_exhausted] message is larger than configured readMaxBytes 3 after decompression"
+          );
+        }
+      });
+    });
+  });
+
+  describe("combined transform round-trip", function () {
+    const endFlag = 0b10000000;
+    const goldenItemsWithEnd = [
+      { value: "a", end: false },
+      { value: "b", end: false },
+      { value: "end", end: true },
+    ];
+    const serialization: Serialization<string> = {
+      serialize(data: string): Uint8Array {
+        return new TextEncoder().encode(data);
+      },
+      parse(data: Uint8Array): string {
+        return new TextDecoder().decode(data);
+      },
+    };
+    const endSerialization: Serialization<string> = {
+      serialize(data: string): Uint8Array {
+        return new TextEncoder().encode(data + ".");
+      },
+      parse(data: Uint8Array): string {
+        return new TextDecoder().decode(data).slice(0, -1);
+      },
+    };
+    const compressionRevers: Compression = {
+      name: "fake",
+      compress(bytes) {
+        const b = new Uint8Array(bytes.byteLength);
+        b.set(bytes, 0);
+        return Promise.resolve(b.reverse());
+      },
+      decompress(bytes, readMaxBytes) {
+        if (bytes.byteLength > readMaxBytes) {
+          return Promise.reject(
+            new ConnectError(
+              `message is larger than configured readMaxBytes ${readMaxBytes} after decompression`,
+              Code.ResourceExhausted
+            )
+          );
+        }
+        const b = new Uint8Array(bytes.byteLength);
+        b.set(bytes, 0);
+        return Promise.resolve(b.reverse());
+      },
+    };
+
+    it("should serialize, compress, join, split, decompress, and parse", async function () {
+      const stream = createReadableStream(goldenItemsWithEnd)
+        .pipeThrough(
+          transformSerializeWithEnd(serialization, endSerialization, endFlag),
+          {}
+        )
+        .pipeThrough(
+          transformCompress(compressionRevers, Number.MAX_SAFE_INTEGER, 0),
+          {}
+        )
+        .pipeThrough(transformJoin(Number.MAX_SAFE_INTEGER), {})
+        .pipeThrough(transformSplit(Number.MAX_SAFE_INTEGER), {})
+        .pipeThrough(
+          transformDecompress(compressionRevers, Number.MAX_SAFE_INTEGER),
+          {}
+        )
+        .pipeThrough(
+          transformParseWithEnd(serialization, endSerialization, endFlag),
+          {}
+        );
+      const result = await readAll(stream);
+      expect(result).toEqual(goldenItemsWithEnd);
+    });
+  });
+});

--- a/packages/connect-core/src/transform-stream.ts
+++ b/packages/connect-core/src/transform-stream.ts
@@ -1,0 +1,320 @@
+// Copyright 2021-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Code } from "./code.js";
+import { ConnectError } from "./connect-error.js";
+import type { EnvelopedMessage } from "./envelope.js";
+import type { Serialization } from "./serialization.js";
+import { compressedFlag, Compression } from "./compression.js";
+
+/**
+ * ValueOrEnd is either a value, or and end type. It is the counterpart of an
+ * enveloped message - which can have a flag indicating a special message at
+ * the end of the stream - but in deserialized form.
+ */
+type ValueOrEnd<T, E> = { end: false; value: T } | { end: true; value: E };
+
+/**
+ * Creates a WHATWG TransformStream that takes a value or special end type, and
+ * serializes it as an enveloped message.
+ *
+ * For example, an input with { end: true, value: ... } is serialized using
+ * the given endSerialization, and the resulting enveloped message has the
+ * given endStreamFlag.
+ *
+ * An input with { end: false, value: ... } is serialized using the given
+ * serialization, and the resulting enveloped message does not have the given
+ * endStreamFlag.
+ */
+export function transformSerializeWithEnd<T, E>(
+  serialization: Serialization<T>,
+  endSerialization: Serialization<E>,
+  endStreamFlag: number
+): TransformStream<ValueOrEnd<T, E>, EnvelopedMessage> {
+  return new TransformStream<ValueOrEnd<T, E>, EnvelopedMessage>({
+    transform(chunk, controller) {
+      let data: Uint8Array;
+      let flags = 0;
+      if (chunk.end) {
+        flags = flags | endStreamFlag;
+        try {
+          data = endSerialization.serialize(chunk.value);
+        } catch (e) {
+          return controller.error(
+            new ConnectError("failed to serialize end", Code.Internal)
+          );
+        }
+      } else {
+        try {
+          data = serialization.serialize(chunk.value);
+        } catch (e) {
+          return controller.error(
+            new ConnectError("failed to serialize", Code.Internal)
+          );
+        }
+      }
+      controller.enqueue({ flags, data });
+    },
+  });
+}
+
+/**
+ * Creates a WHATWG TransformStream that takes an enveloped message as input,
+ * and returns either a value or a special end type.
+ *
+ * For example, if the given endStreamFlag is set for an input envelope, its
+ * payload is parsed using the given endSerialization, and an object with
+ * { end: true, value: ... } is returned.
+ *
+ * If the endStreamFlag is not set, the payload is parsed using the given
+ * serialization, and an object with { end: false, value: ... } is returned.
+ */
+export function transformParseWithEnd<T, E>(
+  serialization: Serialization<T>,
+  endSerialization: Serialization<E>,
+  endStreamFlag: number
+): TransformStream<EnvelopedMessage, ValueOrEnd<T, E>> {
+  return new TransformStream<EnvelopedMessage, ValueOrEnd<T, E>>({
+    transform(chunk, controller) {
+      const { flags, data } = chunk;
+      if ((flags & endStreamFlag) === endStreamFlag) {
+        let value: E;
+        try {
+          value = endSerialization.parse(data);
+        } catch (e) {
+          return controller.error(
+            new ConnectError("failed to parse end", Code.InvalidArgument)
+          );
+        }
+        return controller.enqueue({ value, end: true });
+      }
+      let value: T;
+      try {
+        value = serialization.parse(data);
+      } catch (e) {
+        return controller.error(
+          new ConnectError("failed to parse end", Code.InvalidArgument)
+        );
+      }
+      controller.enqueue({ value, end: false });
+    },
+  });
+}
+
+/**
+ * Creates a WHATWG TransformStream that takes a specified type as input, and
+ * serializes it as an enveloped messages.
+ */
+export function transformSerialize<T>(
+  serialization: Serialization<T>
+): TransformStream<T, EnvelopedMessage> {
+  return new TransformStream<T, EnvelopedMessage>({
+    transform(chunk, controller) {
+      let data: Uint8Array;
+      try {
+        data = serialization.serialize(chunk);
+      } catch (e) {
+        return controller.error(
+          new ConnectError("failed to serialize", Code.Internal)
+        );
+      }
+      controller.enqueue({ flags: 0, data });
+    },
+  });
+}
+
+/**
+ * Creates a WHATWG TransformStream that takes enveloped messages as input, and
+ * parses it into the specified type.
+ */
+export function transformParse<T>(
+  serialization: Serialization<T>
+): TransformStream<EnvelopedMessage, T> {
+  return new TransformStream<EnvelopedMessage, T>({
+    transform(chunk, controller) {
+      let data: T;
+      try {
+        data = serialization.parse(chunk.data);
+      } catch (e) {
+        return controller.error(
+          new ConnectError("failed to parse", Code.Internal)
+        );
+      }
+      controller.enqueue(data);
+    },
+  });
+}
+
+/**
+ * Creates a WHATWG TransformStream that takes enveloped messages as input, and
+ * compresses them if they are larger than compressMinBytes.
+ *
+ * An error is raised if an enveloped message is already compressed, or if
+ * the compressed payload is larger than writeMaxBytes.
+ */
+export function transformCompress(
+  compression: Compression,
+  writeMaxBytes: number,
+  compressMinBytes: number
+): TransformStream<EnvelopedMessage, EnvelopedMessage> {
+  return new TransformStream<EnvelopedMessage, EnvelopedMessage>({
+    async transform(chunk, controller) {
+      let { flags, data } = chunk;
+      if ((flags & compressedFlag) === compressedFlag) {
+        return controller.error(
+          new ConnectError(
+            "invalid envelope, already compressed",
+            Code.Internal
+          )
+        );
+      }
+      if (data.byteLength < compressMinBytes) {
+        return controller.enqueue(chunk);
+      }
+      data = await compression.compress(data);
+      if (data.byteLength > writeMaxBytes) {
+        return controller.error(
+          new ConnectError(
+            `message size ${data.byteLength} is larger than configured writeMaxBytes ${writeMaxBytes}`,
+            Code.ResourceExhausted
+          )
+        );
+      }
+      flags = flags | compressedFlag;
+      controller.enqueue({ data, flags });
+    },
+  });
+}
+
+/**
+ * Creates a WHATWG TransformStream that takes enveloped messages as input, and
+ * decompresses them using the given compression.
+ */
+export function transformDecompress(
+  compression: Compression,
+  readMaxBytes: number
+): TransformStream<EnvelopedMessage, EnvelopedMessage> {
+  return new TransformStream<EnvelopedMessage, EnvelopedMessage>({
+    async transform(chunk, controller) {
+      let { flags, data } = chunk;
+      if ((flags & compressedFlag) !== compressedFlag) {
+        return controller.enqueue(chunk);
+      }
+      data = await compression.decompress(data, readMaxBytes);
+      flags = flags ^ compressedFlag;
+      controller.enqueue({ data, flags });
+    },
+  });
+}
+
+/**
+ * Create a WHATWG TransformStream that takes enveloped messages as input and
+ * joins them into a stream of raw bytes.
+ *
+ * The TransformStream raises an error if the payload of an enveloped message
+ * is larger than writeMaxBytes.
+ */
+export function transformJoin(
+  writeMaxBytes: number
+): TransformStream<EnvelopedMessage, Uint8Array> {
+  return new TransformStream<EnvelopedMessage, Uint8Array>({
+    transform(chunk, controller) {
+      const { flags, data } = chunk;
+      if (data.byteLength > writeMaxBytes) {
+        return controller.error(
+          new ConnectError(
+            `message size ${data.byteLength} is larger than configured writeMaxBytes ${writeMaxBytes}`,
+            Code.ResourceExhausted
+          )
+        );
+      }
+      const bytes = new Uint8Array(data.byteLength + 5);
+      bytes.set(data, 5);
+      const v = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+      v.setUint8(0, flags); // first byte is flags
+      v.setUint32(1, data.byteLength); // 4 bytes message length
+      controller.enqueue(bytes);
+    },
+  });
+}
+
+/**
+ * Create a WHATWG TransformStream that takes raw bytes as input and splits them
+ * into enveloped messages.
+ *
+ * The TransformStream raises an error
+ * - if the payload of an enveloped message is larger than readMaxBytes,
+ * - if the stream ended before an enveloped message fully arrived,
+ * - or if the stream ended with extraneous data.
+ */
+export function transformSplit(
+  readMaxBytes: number
+): TransformStream<Uint8Array, EnvelopedMessage> {
+  let buffer = new Uint8Array(0);
+  let header: { length: number; flags: number } | undefined = undefined;
+  return new TransformStream<Uint8Array, EnvelopedMessage>({
+    transform(chunk, controller) {
+      const g = new Uint8Array(buffer.byteLength + chunk.byteLength);
+      g.set(buffer);
+      g.set(chunk, buffer.byteLength);
+      buffer = g;
+      if (buffer.byteLength < 5) {
+        return;
+      }
+      if (!header) {
+        const v = new DataView(buffer.buffer, buffer.byteOffset, 5);
+        const flags = v.getUint8(0); // first byte is flags
+        const length = v.getUint32(1); // 4 bytes message length
+        if (length > readMaxBytes) {
+          return controller.error(
+            new ConnectError(
+              `message size ${length} is larger than configured readMaxBytes ${readMaxBytes}`,
+              Code.ResourceExhausted
+            )
+          );
+        }
+        header = { length, flags };
+      }
+      if (buffer.byteLength - 5 < header.length) {
+        return;
+      }
+      const data = buffer.subarray(5, 5 + header.length);
+      buffer = buffer.subarray(5 + header.length);
+      controller.enqueue({ flags: header.flags, data });
+      header = undefined;
+    },
+    flush(controller) {
+      if (header) {
+        controller.error(
+          new ConnectError(
+            `protocol error: promised ${header.length} bytes in envelope, got ${
+              buffer.byteLength - 5
+            }`,
+            Code.InvalidArgument
+          )
+        );
+        return;
+      }
+      if (buffer.byteLength) {
+        controller.error(
+          new ConnectError(
+            `protocol error: received ${buffer.byteLength} extra bytes`,
+            Code.DataLoss
+          )
+        );
+        return;
+      }
+    },
+  });
+}

--- a/packages/connect-core/src/transform-stream.ts
+++ b/packages/connect-core/src/transform-stream.ts
@@ -52,7 +52,13 @@ export function transformSerializeWithEnd<T, E>(
           data = endSerialization.serialize(chunk.value);
         } catch (e) {
           return controller.error(
-            new ConnectError("failed to serialize end", Code.Internal)
+            new ConnectError(
+              "failed to serialize end",
+              Code.Internal,
+              undefined,
+              undefined,
+              e
+            )
           );
         }
       } else {
@@ -60,7 +66,13 @@ export function transformSerializeWithEnd<T, E>(
           data = serialization.serialize(chunk.value);
         } catch (e) {
           return controller.error(
-            new ConnectError("failed to serialize", Code.Internal)
+            new ConnectError(
+              "failed to serialize",
+              Code.Internal,
+              undefined,
+              undefined,
+              e
+            )
           );
         }
       }
@@ -94,7 +106,13 @@ export function transformParseWithEnd<T, E>(
           value = endSerialization.parse(data);
         } catch (e) {
           return controller.error(
-            new ConnectError("failed to parse end", Code.InvalidArgument)
+            new ConnectError(
+              "failed to parse end",
+              Code.InvalidArgument,
+              undefined,
+              undefined,
+              e
+            )
           );
         }
         return controller.enqueue({ value, end: true });
@@ -104,7 +122,13 @@ export function transformParseWithEnd<T, E>(
         value = serialization.parse(data);
       } catch (e) {
         return controller.error(
-          new ConnectError("failed to parse end", Code.InvalidArgument)
+          new ConnectError(
+            "failed to parse end",
+            Code.InvalidArgument,
+            undefined,
+            undefined,
+            e
+          )
         );
       }
       controller.enqueue({ value, end: false });
@@ -126,7 +150,13 @@ export function transformSerialize<T>(
         data = serialization.serialize(chunk);
       } catch (e) {
         return controller.error(
-          new ConnectError("failed to serialize", Code.Internal)
+          new ConnectError(
+            "failed to serialize",
+            Code.Internal,
+            undefined,
+            undefined,
+            e
+          )
         );
       }
       controller.enqueue({ flags: 0, data });
@@ -148,7 +178,13 @@ export function transformParse<T>(
         data = serialization.parse(chunk.data);
       } catch (e) {
         return controller.error(
-          new ConnectError("failed to parse", Code.Internal)
+          new ConnectError(
+            "failed to parse",
+            Code.Internal,
+            undefined,
+            undefined,
+            e
+          )
         );
       }
       controller.enqueue(data);

--- a/packages/connect-core/src/whatwg-stream-helper.spec.ts
+++ b/packages/connect-core/src/whatwg-stream-helper.spec.ts
@@ -1,0 +1,114 @@
+// Copyright 2021-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  ReadableStream as NodeReadableStream,
+  TransformStream as NodeTransformStream,
+  WritableStream as NodeWritableStream,
+} from "stream/web";
+
+/**
+ * Make the WHATWG stream implementation of Node.js v16 available in the global
+ * scope.
+ */
+export function node16WhatwgStreamPolyfill() {
+  // node >= v16 has an implementation for WHATWG streams, but doesn't expose
+  // them in the global scope, nor globalThis.
+  if (typeof globalThis.ReadableStream !== "function") {
+    globalThis.ReadableStream =
+      NodeReadableStream as unknown as typeof ReadableStream;
+  }
+  if (typeof globalThis.WritableStream !== "function") {
+    globalThis.WritableStream =
+      NodeWritableStream as unknown as typeof WritableStream;
+  }
+  if (typeof globalThis.TransformStream !== "function") {
+    globalThis.TransformStream =
+      NodeTransformStream as unknown as typeof TransformStream;
+  }
+}
+
+/**
+ * Create a WHATWG ReadableStream from a Uint8Array for usage in tests.
+ */
+export function createReadableByteStream(
+  bytes: Uint8Array,
+  chunkSize = 2,
+  delay = 5
+) {
+  let offset = 0;
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      await new Promise((resolve) => setTimeout(resolve, delay));
+      const end = Math.min(offset + chunkSize, bytes.byteLength);
+      controller.enqueue(bytes.slice(offset, end));
+      offset = end;
+      if (offset === bytes.length) {
+        controller.close();
+      }
+    },
+  });
+}
+
+/**
+ * Create a WHATWG ReadableStream from an array of items for usage in tests.
+ */
+export function createReadableStream<T>(
+  items: T[],
+  delay = 2
+): ReadableStream<T> {
+  const source = items.concat();
+  return new ReadableStream<T>({
+    async pull(controller) {
+      await new Promise((resolve) => setTimeout(resolve, delay));
+      const item = source.shift();
+      if (item !== undefined) {
+        controller.enqueue(item);
+        return;
+      }
+      controller.close();
+    },
+  });
+}
+
+/**
+ * Read all items from a WHATWG ReadableStream for usage in tests.
+ */
+export async function readAll<T>(stream: ReadableStream<T>): Promise<T[]> {
+  const reader = stream.getReader();
+  const values: T[] = [];
+  for (;;) {
+    const r = await reader.read();
+    if (r.done) {
+      break;
+    }
+    values.push(r.value);
+  }
+  return values;
+}
+
+/**
+ * Read all byte chunks from a WHATWG ReadableStream and concatenate them.
+ * For usage in tests.
+ */
+export async function readAllBytes(
+  stream: ReadableStream<Uint8Array>
+): Promise<Uint8Array> {
+  return (await readAll(stream)).reduce((p, c) => {
+    const n = new Uint8Array(p.byteLength + c.byteLength);
+    n.set(p, 0);
+    n.set(c, p.byteLength);
+    return n;
+  }, new Uint8Array(0));
+}

--- a/packages/connect-node-test/src/extra/node-transform-stream.spec.ts
+++ b/packages/connect-node-test/src/extra/node-transform-stream.spec.ts
@@ -1,0 +1,125 @@
+// Copyright 2021-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { EnvelopedMessage, Serialization } from "@bufbuild/connect-core";
+import { Readable, Writable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import {
+  deserializeStream,
+  transformSerialize,
+} from "./node-transform-stream.js";
+
+// Both Node.js and WHATWG streams have a concept of stream transformation.
+// The main differences between both:
+//
+// 1. Node.js streams do not have TypeScript typings for chunks.
+// 2. Node.js pipeline always starts with a readable and ends with a writable,
+//    while WHATWG stream transforms happen on the readable side exclusively.
+//
+describe("transforming Node.js streams", function () {
+  const fakeSerialization: Serialization<string> = {
+    serialize(data: string): Uint8Array {
+      return new TextEncoder().encode(data);
+    },
+    parse(data: Uint8Array): string {
+      return new TextDecoder().decode(data);
+    },
+  };
+
+  it("should serialize to envelopes", async function () {
+    const s = createWritableStream<EnvelopedMessage>();
+    await pipeline(
+      createReadableStream(["a", "b", "c"]),
+      transformSerialize(fakeSerialization),
+      s
+    );
+    expect(s.getWrittenItems()).toEqual([
+      {
+        data: new TextEncoder().encode("a"),
+        flags: 0b00000000,
+      },
+      {
+        data: new TextEncoder().encode("b"),
+        flags: 0b00000000,
+      },
+      {
+        data: new TextEncoder().encode("c"),
+        flags: 0b00000000,
+      },
+    ]);
+  });
+
+  it("should serialize and deserialize", async function () {
+    const s = createWritableStream<string>();
+    await pipeline(
+      createReadableStream(["a", "b", "c"]),
+      transformSerialize(fakeSerialization),
+      deserializeStream(fakeSerialization),
+      s
+    );
+    expect(s.getWrittenItems()).toEqual(["a", "b", "c"]);
+  });
+});
+
+/**
+ * Create a Node.js stream.Readable from an array of items for usage in tests.
+ */
+function createReadableStream<T>(items: T[]): Readable {
+  const source = items.concat();
+  return new Readable({
+    objectMode: true,
+    encoding: undefined,
+    read() {
+      const item = source.shift();
+      if (item !== undefined) {
+        this.push(item);
+        return;
+      }
+      this.push(null);
+    },
+  });
+}
+
+/**
+ * Create a Node.js stream.Writable from an array of items for usage in tests.
+ */
+function createWritableStream<T>() {
+  const sink: T[] = [];
+  let err: Error | null = null;
+  const w = new Writable({
+    decodeStrings: false,
+    objectMode: true,
+    defaultEncoding: undefined,
+    write(
+      chunk: unknown,
+      encoding: BufferEncoding,
+      callback: (error?: Error | null) => void
+    ) {
+      sink.push(chunk as T);
+      callback(null);
+    },
+    destroy(error: Error | null, callback: (error: Error | null) => void) {
+      err = error;
+      callback(error);
+    },
+  });
+  return Object.assign(w, {
+    getWrittenItems(): T[] {
+      if (err !== null) {
+        throw err;
+      }
+      return sink;
+    },
+  });
+}

--- a/packages/connect-node-test/src/extra/node-transform-stream.ts
+++ b/packages/connect-node-test/src/extra/node-transform-stream.ts
@@ -1,0 +1,76 @@
+// Copyright 2021-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Transform, TransformCallback } from "node:stream";
+import {
+  Code,
+  ConnectError,
+  EnvelopedMessage,
+  Serialization,
+} from "@bufbuild/connect-core";
+
+/**
+ * Creates a Node.js stream.Transform that takes a specified type as input, and
+ * serializes it as an enveloped messages.
+ */
+export function transformSerialize<T>(serializer: Serialization<T>): Transform {
+  return new Transform({
+    decodeStrings: false,
+    objectMode: true,
+    readableObjectMode: true,
+    writableObjectMode: true,
+    transform(
+      chunk: unknown,
+      encoding: BufferEncoding,
+      callback: TransformCallback
+    ) {
+      let data: Uint8Array;
+      try {
+        data = serializer.serialize(chunk as T);
+      } catch (e) {
+        return callback(new ConnectError("failed to serialize", Code.Internal));
+      }
+      this.push({ flags: 0, data });
+      callback();
+    },
+  });
+}
+
+/**
+ * Creates a Node.js stream.Transform that takes enveloped messages as input,
+ * and parses it into the specified type.
+ */
+export function deserializeStream<T>(serializer: Serialization<T>): Transform {
+  return new Transform({
+    decodeStrings: false,
+    encoding: undefined,
+    objectMode: true,
+    readableObjectMode: true,
+    writableObjectMode: true,
+    transform(
+      chunk: unknown,
+      encoding: BufferEncoding,
+      callback: TransformCallback
+    ) {
+      let data: T;
+      try {
+        data = serializer.parse((chunk as EnvelopedMessage).data);
+      } catch (e) {
+        return callback(new ConnectError("failed to parse", Code.Internal));
+      }
+      this.push(data);
+      callback(null);
+    },
+  });
+}

--- a/packages/connect-node/src/compression.ts
+++ b/packages/connect-node/src/compression.ts
@@ -14,26 +14,13 @@
 
 import * as zlib from "zlib";
 import { promisify } from "util";
-import { Code, ConnectError } from "@bufbuild/connect-core";
+import { Code, ConnectError, Compression } from "@bufbuild/connect-core";
 import { getNodeErrorProps } from "./private/node-error.js";
-
-export interface Compression {
-  name: string;
-  compress: (bytes: Uint8Array) => Promise<Uint8Array>;
-  decompress: (bytes: Uint8Array, readMaxBytes: number) => Promise<Uint8Array>;
-}
 
 const gzip = promisify(zlib.gzip);
 const gunzip = promisify(zlib.gunzip);
 const brotliCompress = promisify(zlib.brotliCompress);
 const brotliDecompress = promisify(zlib.brotliDecompress);
-
-/**
- * compressedFlag indicates that the data in a EnvelopedMessage is
- * compressed. It has the same meaning in the gRPC-Web, gRPC-HTTP2,
- * and Connect protocols.
- */
-export const compressedFlag = 0b00000001;
 
 export const compressionGzip: Compression = {
   name: "gzip",

--- a/packages/connect-node/src/connect-http-transport.ts
+++ b/packages/connect-node/src/connect-http-transport.ts
@@ -15,6 +15,8 @@
 import {
   appendHeaders,
   Code,
+  compressedFlag,
+  Compression,
   ConnectError,
   createClientMethodSerializers,
   createMethodUrl,
@@ -62,12 +64,7 @@ import {
   webHeaderToNodeHeaders,
 } from "./private/web-header-to-node-headers.js";
 import { assert } from "./private/assert.js";
-import {
-  compressedFlag,
-  Compression,
-  compressionBrotli,
-  compressionGzip,
-} from "./compression.js";
+import { compressionBrotli, compressionGzip } from "./compression.js";
 import { validateReadMaxBytesOption } from "./private/validate-read-max-bytes-option.js";
 import {
   connectCreateRequestHeaderWithCompression,

--- a/packages/connect-node/src/connect-http2-transport.ts
+++ b/packages/connect-node/src/connect-http2-transport.ts
@@ -15,6 +15,8 @@
 import {
   appendHeaders,
   Code,
+  compressedFlag,
+  Compression,
   ConnectError,
   createClientMethodSerializers,
   createMethodUrl,
@@ -61,7 +63,6 @@ import {
   write,
 } from "./private/io.js";
 import { connectErrorFromNodeReason } from "./private/node-error.js";
-import { compressedFlag, Compression } from "./compression.js";
 import { compressionBrotli, compressionGzip } from "./compression.js";
 import { validateReadMaxBytesOption } from "./private/validate-read-max-bytes-option.js";
 

--- a/packages/connect-node/src/connect-protocol.ts
+++ b/packages/connect-node/src/connect-protocol.ts
@@ -18,6 +18,8 @@ import {
   ConnectError,
   encodeEnvelope,
   connectErrorFromReason,
+  Compression,
+  compressedFlag,
 } from "@bufbuild/connect-core";
 import {
   codeToHttpStatus,
@@ -54,7 +56,6 @@ import {
   readToEnd,
   write,
 } from "./private/io.js";
-import { compressedFlag, Compression } from "./compression.js";
 import { compressionBrotli, compressionGzip } from "./compression.js";
 import { validateReadMaxBytesOption } from "./private/validate-read-max-bytes-option.js";
 import { connectErrorFromNodeReason } from "./private/node-error.js";

--- a/packages/connect-node/src/grpc-http-transport.ts
+++ b/packages/connect-node/src/grpc-http-transport.ts
@@ -16,6 +16,8 @@ import * as http from "http";
 import * as https from "https";
 import {
   Code,
+  compressedFlag,
+  Compression,
   ConnectError,
   createClientMethodSerializers,
   createMethodUrl,
@@ -54,12 +56,7 @@ import {
   write,
 } from "./private/io.js";
 import type { ReadableStreamReadResultLike } from "./lib.dom.streams.js";
-import {
-  compressionGzip,
-  compressionBrotli,
-  Compression,
-  compressedFlag,
-} from "./compression.js";
+import { compressionGzip, compressionBrotli } from "./compression.js";
 import { validateReadMaxBytesOption } from "./private/validate-read-max-bytes-option.js";
 import {
   grpcCreateRequestHeaderWithCompression,

--- a/packages/connect-node/src/grpc-http2-transport.ts
+++ b/packages/connect-node/src/grpc-http2-transport.ts
@@ -14,6 +14,8 @@
 
 import {
   Code,
+  compressedFlag,
+  Compression,
   ConnectError,
   createClientMethodSerializers,
   createMethodUrl,
@@ -56,12 +58,7 @@ import {
 } from "./private/io.js";
 import { webHeaderToNodeHeaders } from "./private/web-header-to-node-headers.js";
 import { connectErrorFromNodeReason } from "./private/node-error.js";
-import {
-  compressedFlag,
-  Compression,
-  compressionBrotli,
-  compressionGzip,
-} from "./compression.js";
+import { compressionBrotli, compressionGzip } from "./compression.js";
 import { validateReadMaxBytesOption } from "./private/validate-read-max-bytes-option.js";
 
 const messageFlag = 0b00000000;

--- a/packages/connect-node/src/grpc-protocol.ts
+++ b/packages/connect-node/src/grpc-protocol.ts
@@ -14,6 +14,8 @@
 
 import {
   Code,
+  compressedFlag,
+  Compression,
   ConnectError,
   connectErrorFromReason,
   encodeEnvelope,
@@ -43,12 +45,7 @@ import type * as http from "http";
 import type * as http2 from "http2";
 import { end, endWithHttpStatus, readEnvelope, write } from "./private/io.js";
 import { compressionNegotiate } from "./private/compression-negotiate.js";
-import {
-  compressedFlag,
-  Compression,
-  compressionBrotli,
-  compressionGzip,
-} from "./compression.js";
+import { compressionBrotli, compressionGzip } from "./compression.js";
 import { validateReadMaxBytesOption } from "./private/validate-read-max-bytes-option.js";
 
 const messageFlag = 0b00000000;
@@ -104,10 +101,11 @@ export function createGrpcProtocol(
             const context: HandlerContext = {
               method: spec.method,
               service: spec.service,
-              requestHeader,
+              requestHeader: nodeHeaderToWebHeader(req.headers),
               responseHeader: grpcCreateResponseHeader(type.binary),
               responseTrailer: new Headers(),
             };
+
             const timeout = parseTimeout(requestHeader.get(grpcTimeoutHeader));
 
             if (timeout instanceof ConnectError) {

--- a/packages/connect-node/src/grpc-web-http-transport.ts
+++ b/packages/connect-node/src/grpc-web-http-transport.ts
@@ -26,6 +26,8 @@ import {
   UnaryRequest,
   UnaryResponse,
   Code,
+  Compression,
+  compressedFlag,
 } from "@bufbuild/connect-core";
 import { validateTrailer } from "@bufbuild/connect-core/protocol-grpc";
 import {
@@ -54,12 +56,7 @@ import { end, readEnvelope, write } from "./private/io.js";
 import { assert } from "./private/assert.js";
 import { defer } from "./private/defer.js";
 import type { ReadableStreamReadResultLike } from "./lib.dom.streams.js";
-import {
-  compressedFlag,
-  Compression,
-  compressionBrotli,
-  compressionGzip,
-} from "./compression.js";
+import { compressionBrotli, compressionGzip } from "./compression.js";
 import { validateReadMaxBytesOption } from "./private/validate-read-max-bytes-option.js";
 import {
   grpcWebCreateRequestHeaderWithCompression,

--- a/packages/connect-node/src/grpc-web-http2-transport.ts
+++ b/packages/connect-node/src/grpc-web-http2-transport.ts
@@ -14,6 +14,8 @@
 
 import {
   Code,
+  compressedFlag,
+  Compression,
   ConnectError,
   createClientMethodSerializers,
   createMethodUrl,
@@ -52,12 +54,7 @@ import { defer } from "./private/defer.js";
 import { end, readEnvelope, readResponseHeader, write } from "./private/io.js";
 import { webHeaderToNodeHeaders } from "./private/web-header-to-node-headers.js";
 import { connectErrorFromNodeReason } from "./private/node-error.js";
-import {
-  type Compression,
-  compressionBrotli,
-  compressionGzip,
-  compressedFlag,
-} from "./compression.js";
+import { compressionBrotli, compressionGzip } from "./compression.js";
 import { validateReadMaxBytesOption } from "./private/validate-read-max-bytes-option.js";
 
 /**

--- a/packages/connect-node/src/grpc-web-protocol.ts
+++ b/packages/connect-node/src/grpc-web-protocol.ts
@@ -14,6 +14,8 @@
 
 import {
   Code,
+  compressedFlag,
+  Compression,
   ConnectError,
   connectErrorFromReason,
   encodeEnvelope,
@@ -46,12 +48,7 @@ import {
 import type * as http from "http";
 import type * as http2 from "http2";
 import { end, endWithHttpStatus, readEnvelope, write } from "./private/io.js";
-import {
-  compressedFlag,
-  Compression,
-  compressionBrotli,
-  compressionGzip,
-} from "./compression.js";
+import { compressionBrotli, compressionGzip } from "./compression.js";
 import { compressionNegotiate } from "./private/compression-negotiate.js";
 import { validateReadMaxBytesOption } from "./private/validate-read-max-bytes-option.js";
 

--- a/packages/connect-node/src/private/compression-negotiate.ts
+++ b/packages/connect-node/src/private/compression-negotiate.ts
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type { Compression } from "../compression.js";
-import { Code, ConnectError } from "@bufbuild/connect-core";
+import { Code, ConnectError, Compression } from "@bufbuild/connect-core";
 
 /**
  * compressionNegotiate validates the request encoding and determines

--- a/packages/connect-web-bench/README.md
+++ b/packages/connect-web-bench/README.md
@@ -10,6 +10,6 @@ it like a web server would usually do.
 
 | code generator | bundle size        | minified               | compressed           |
 |----------------|-------------------:|-----------------------:|---------------------:|
-| connect-web    | 102,666 b | 43,927 b | 12,052 b |
+| connect-web    | 102,675 b | 43,927 b | 12,052 b |
 | connect-web (legacy) | 94,850 b | 40,976 b | 11,358 b |
 | grpc-web       | 414,222 b    | 301,127 b    | 53,226 b |


### PR DESCRIPTION
This adds transform streams for compression, serialization, and enveloping to @bufbuild/connect-core. We will use this feature to streamline the handler and client implementations in @bufbuild/connect-node.