### PR TITLE
Use web headers consistently

### DIFF
--- a/packages/connect-node/src/connect-protocol.ts
+++ b/packages/connect-node/src/connect-protocol.ts
@@ -296,7 +296,7 @@ export function createConnectProtocol(
             if (
               shouldRequireHeader &&
               requestHeader.get(connectProtocolVersionHeader) !==
-              connectProtocolVersion
+                connectProtocolVersion
             ) {
               return await endWithHttpStatus(
                 res,
@@ -451,7 +451,7 @@ export function createConnectProtocol(
             if (
               shouldRequireHeader &&
               requestHeader.get(connectProtocolVersionHeader) !==
-              connectProtocolVersion
+                connectProtocolVersion
             ) {
               return await endWithHttpStatus(
                 res,
@@ -611,7 +611,7 @@ export function createConnectProtocol(
             if (
               shouldRequireHeader &&
               requestHeader.get(connectProtocolVersionHeader) !==
-              connectProtocolVersion
+                connectProtocolVersion
             ) {
               return await endWithHttpStatus(
                 res,

--- a/packages/connect-node/src/connect-protocol.ts
+++ b/packages/connect-node/src/connect-protocol.ts
@@ -108,7 +108,6 @@ export function createConnectProtocol(
           return async (req, res) => {
             const requestHeader = nodeHeaderToWebHeader(req.headers);
             const type = parseContentType(requestHeader.get(headerContentType));
-
             if (type === undefined) {
               return await endWithHttpStatus(
                 res,
@@ -126,7 +125,7 @@ export function createConnectProtocol(
 
             if (
               shouldRequireHeader &&
-              req.headers[connectProtocolVersionHeader] !==
+              requestHeader.get(connectProtocolVersionHeader) !==
                 connectProtocolVersion
             ) {
               return await endWithHttpStatus(
@@ -139,7 +138,7 @@ export function createConnectProtocol(
             const context: HandlerContext = {
               method: spec.method,
               service: spec.service,
-              requestHeader: requestHeader,
+              requestHeader,
               responseHeader: connectCreateResponseHeader(
                 spec.method.kind,
                 type.binary
@@ -150,7 +149,6 @@ export function createConnectProtocol(
             const timeout = parseTimeout(
               requestHeader.get(connectTimeoutHeader)
             );
-
             if (timeout instanceof ConnectError) {
               return await endWithConnectUnaryError(
                 res,
@@ -161,7 +159,6 @@ export function createConnectProtocol(
                 compressMinBytes
               );
             }
-
             if (typeof timeout === "number") {
               res.setTimeout(timeout, () => {
                 return void endWithConnectUnaryError(
@@ -270,7 +267,6 @@ export function createConnectProtocol(
           return async (req, res) => {
             const requestHeader = nodeHeaderToWebHeader(req.headers);
             const type = parseContentType(requestHeader.get(headerContentType));
-
             if (type === undefined) {
               return await endWithHttpStatus(
                 res,
@@ -299,8 +295,8 @@ export function createConnectProtocol(
 
             if (
               shouldRequireHeader &&
-              req.headers[connectProtocolVersionHeader] !==
-                connectProtocolVersion
+              requestHeader.get(connectProtocolVersionHeader) !==
+              connectProtocolVersion
             ) {
               return await endWithHttpStatus(
                 res,
@@ -312,7 +308,6 @@ export function createConnectProtocol(
             const timeout = parseTimeout(
               requestHeader.get(connectTimeoutHeader)
             );
-
             if (timeout instanceof ConnectError) {
               return await endWithConnectEndStream(
                 res,
@@ -323,7 +318,6 @@ export function createConnectProtocol(
                 compressMinBytes
               );
             }
-
             if (typeof timeout === "number") {
               res.setTimeout(timeout, () => {
                 return void endWithConnectEndStream(
@@ -439,7 +433,6 @@ export function createConnectProtocol(
           return async (req, res) => {
             const requestHeader = nodeHeaderToWebHeader(req.headers);
             const type = parseContentType(requestHeader.get(headerContentType));
-
             if (type === undefined) {
               return await endWithHttpStatus(
                 res,
@@ -457,8 +450,8 @@ export function createConnectProtocol(
 
             if (
               shouldRequireHeader &&
-              req.headers[connectProtocolVersionHeader] !==
-                connectProtocolVersion
+              requestHeader.get(connectProtocolVersionHeader) !==
+              connectProtocolVersion
             ) {
               return await endWithHttpStatus(
                 res,
@@ -470,7 +463,7 @@ export function createConnectProtocol(
             const context: HandlerContext = {
               method: spec.method,
               service: spec.service,
-              requestHeader: nodeHeaderToWebHeader(req.headers),
+              requestHeader,
               responseHeader: connectCreateResponseHeader(
                 spec.method.kind,
                 type.binary
@@ -481,7 +474,6 @@ export function createConnectProtocol(
             const timeout = parseTimeout(
               requestHeader.get(connectTimeoutHeader)
             );
-
             if (timeout instanceof ConnectError) {
               return await endWithConnectEndStream(
                 res,
@@ -492,7 +484,6 @@ export function createConnectProtocol(
                 compressMinBytes
               );
             }
-
             if (typeof timeout === "number") {
               res.setTimeout(timeout, () => {
                 return void endWithConnectEndStream(
@@ -602,7 +593,6 @@ export function createConnectProtocol(
           return async (req, res) => {
             const requestHeader = nodeHeaderToWebHeader(req.headers);
             const type = parseContentType(requestHeader.get(headerContentType));
-
             if (type === undefined) {
               return await endWithHttpStatus(
                 res,
@@ -620,8 +610,8 @@ export function createConnectProtocol(
 
             if (
               shouldRequireHeader &&
-              req.headers[connectProtocolVersionHeader] !==
-                connectProtocolVersion
+              requestHeader.get(connectProtocolVersionHeader) !==
+              connectProtocolVersion
             ) {
               return await endWithHttpStatus(
                 res,
@@ -633,7 +623,7 @@ export function createConnectProtocol(
             const context: HandlerContext = {
               method: spec.method,
               service: spec.service,
-              requestHeader: nodeHeaderToWebHeader(req.headers),
+              requestHeader,
               responseHeader: connectCreateResponseHeader(
                 spec.method.kind,
                 type.binary
@@ -644,7 +634,6 @@ export function createConnectProtocol(
             const timeout = parseTimeout(
               requestHeader.get(connectTimeoutHeader)
             );
-
             if (timeout instanceof ConnectError) {
               return await endWithConnectEndStream(
                 res,
@@ -655,7 +644,6 @@ export function createConnectProtocol(
                 compressMinBytes
               );
             }
-
             if (typeof timeout === "number") {
               res.setTimeout(timeout, () => {
                 return void endWithConnectEndStream(

--- a/packages/connect-node/src/grpc-web-protocol.ts
+++ b/packages/connect-node/src/grpc-web-protocol.ts
@@ -57,7 +57,8 @@ import { validateReadMaxBytesOption } from "./private/validate-read-max-bytes-op
 
 const headerEncoding = "Grpc-Encoding";
 const headerAcceptEncoding = "Grpc-Accept-Encoding";
-const timeoutHeader = "Grpc-Timeout";
+const headerContentType = "Content-Type";
+const headerTimeout = "Grpc-Timeout";
 
 /**
  * Options for creating a gRPC-web Protocol instance.
@@ -94,8 +95,7 @@ export function createGrpcWebProtocol(
         case MethodKind.Unary:
           return async (req, res) => {
             const requestHeader = nodeHeaderToWebHeader(req.headers);
-            const type = parseContentType(req.headers["content-type"] ?? null);
-
+            const type = parseContentType(requestHeader.get(headerContentType));
             if (type === undefined) {
               return await endWithHttpStatus(
                 res,
@@ -114,16 +114,15 @@ export function createGrpcWebProtocol(
             const context: HandlerContext = {
               method: spec.method,
               service: spec.service,
-              requestHeader: nodeHeaderToWebHeader(req.headers),
+              requestHeader,
               responseHeader: createResponseHeader(type.binary),
               responseTrailer: new Headers(),
             };
-            const timeout = parseTimeout(requestHeader.get(timeoutHeader));
 
+            const timeout = parseTimeout(requestHeader.get(headerTimeout));
             if (timeout instanceof ConnectError) {
               return await endWithGrpcWebTrailer(res, context, timeout);
             }
-
             if (typeof timeout === "number") {
               res.setTimeout(timeout, () => {
                 return void endWithGrpcWebTrailer(
@@ -214,8 +213,7 @@ export function createGrpcWebProtocol(
         case MethodKind.ServerStreaming: {
           return async (req, res) => {
             const requestHeader = nodeHeaderToWebHeader(req.headers);
-            const type = parseContentType(req.headers["content-type"] ?? null);
-
+            const type = parseContentType(requestHeader.get(headerContentType));
             if (type === undefined) {
               return await endWithHttpStatus(
                 res,
@@ -238,12 +236,11 @@ export function createGrpcWebProtocol(
               responseHeader: createResponseHeader(type.binary),
               responseTrailer: new Headers(),
             };
-            const timeout = parseTimeout(requestHeader.get(timeoutHeader));
 
+            const timeout = parseTimeout(requestHeader.get(headerTimeout));
             if (timeout instanceof ConnectError) {
               return await endWithGrpcWebTrailer(res, context, timeout);
             }
-
             if (typeof timeout === "number") {
               res.setTimeout(timeout, () => {
                 return void endWithGrpcWebTrailer(
@@ -355,8 +352,7 @@ export function createGrpcWebProtocol(
         case MethodKind.ClientStreaming: {
           return async (req, res) => {
             const requestHeader = nodeHeaderToWebHeader(req.headers);
-            const type = parseContentType(req.headers["content-type"] ?? null);
-
+            const type = parseContentType(requestHeader.get(headerContentType));
             if (type === undefined) {
               return await endWithHttpStatus(
                 res,
@@ -375,16 +371,15 @@ export function createGrpcWebProtocol(
             const context: HandlerContext = {
               method: spec.method,
               service: spec.service,
-              requestHeader: nodeHeaderToWebHeader(req.headers),
+              requestHeader,
               responseHeader: createResponseHeader(type.binary),
               responseTrailer: new Headers(),
             };
-            const timeout = parseTimeout(requestHeader.get(timeoutHeader));
 
+            const timeout = parseTimeout(requestHeader.get(headerTimeout));
             if (timeout instanceof ConnectError) {
               return await endWithGrpcWebTrailer(res, context, timeout);
             }
-
             if (typeof timeout === "number") {
               res.setTimeout(timeout, () => {
                 return void endWithGrpcWebTrailer(
@@ -495,8 +490,7 @@ export function createGrpcWebProtocol(
         case MethodKind.BiDiStreaming: {
           return async (req, res) => {
             const requestHeader = nodeHeaderToWebHeader(req.headers);
-            const type = parseContentType(req.headers["content-type"] ?? null);
-
+            const type = parseContentType(requestHeader.get(headerContentType));
             if (type === undefined) {
               return await endWithHttpStatus(
                 res,
@@ -519,12 +513,11 @@ export function createGrpcWebProtocol(
               responseHeader: createResponseHeader(type.binary),
               responseTrailer: new Headers(),
             };
-            const timeout = parseTimeout(requestHeader.get(timeoutHeader));
 
+            const timeout = parseTimeout(requestHeader.get(headerTimeout));
             if (timeout instanceof ConnectError) {
               return await endWithGrpcWebTrailer(res, context, timeout);
             }
-
             if (typeof timeout === "number") {
               res.setTimeout(timeout, () => {
                 return void endWithGrpcWebTrailer(


### PR DESCRIPTION
We convert Node headers to web headers in the protocol handlers. This removes a couple of places where we still accessed the Node headers instead of the already converted headers. This is desirable because it removes ambiguity. This also removes a couple of places where we convert to web headers twice.