### PR TITLE
Fix compression for unary methods in the gRPC and the gRPC web client

### DIFF
--- a/packages/connect-core/src/protocol-grpc-web/index.ts
+++ b/packages/connect-core/src/protocol-grpc-web/index.ts
@@ -17,3 +17,8 @@ export { parseContentType } from "./parse-content-type.js";
 export { validateResponse } from "./validate-response.js";
 export { trailerFlag, trailerParse, trailerSerialize } from "./trailer.js";
 export * from "./headers.js";
+export {
+  parseTimeout,
+  setTrailerStatus,
+  validateTrailer,
+} from "../protocol-grpc/index.js";

--- a/packages/connect-node/src/grpc-web-http2-transport.ts
+++ b/packages/connect-node/src/grpc-web-http2-transport.ts
@@ -29,14 +29,16 @@ import {
   UnaryRequest,
   UnaryResponse,
 } from "@bufbuild/connect-core";
-import { validateTrailer } from "@bufbuild/connect-core/protocol-grpc";
 import {
   createRequestHeader,
-  trailerParse,
+  headerAcceptEncoding,
+  headerEncoding,
   trailerFlag,
+  trailerParse,
   validateResponse,
+  validateTrailer,
 } from "@bufbuild/connect-core/protocol-grpc-web";
-import {
+import type {
   AnyMessage,
   BinaryReadOptions,
   BinaryWriteOptions,
@@ -464,15 +466,11 @@ export function grpcWebCreateRequestHeaderWithCompression(
     timeoutMs,
     userProvidedHeaders
   );
-  let acceptEncodingField = "Accept-Encoding";
-  if (methodKind !== MethodKind.Unary) {
-    acceptEncodingField = "GRPC-Web-" + acceptEncodingField;
-    if (sendCompression !== undefined) {
-      result.set("Grpc-Encoding", sendCompression);
-    }
+  if (sendCompression !== undefined) {
+    result.set(headerEncoding, sendCompression);
   }
   if (acceptCompression.length > 0) {
-    result.set(acceptEncodingField, acceptCompression.join(","));
+    result.set(headerAcceptEncoding, acceptCompression.join(","));
   }
   return result;
 }
@@ -486,8 +484,7 @@ export function grpcWebValidateResponseWithCompression(
   validateResponse(useBinaryFormat, status, headers);
 
   let compression: Compression | undefined;
-  const encodingField = "Grpc-Encoding";
-  const encoding = headers.get(encodingField);
+  const encoding = headers.get(headerEncoding);
   if (encoding !== null && encoding.toLowerCase() !== "identity") {
     compression = acceptCompression.find((c) => c.name === encoding);
     if (!compression) {

--- a/packages/connect-node/src/grpc-web-protocol.ts
+++ b/packages/connect-node/src/grpc-web-protocol.ts
@@ -27,8 +27,6 @@ import {
   headerAcceptEncoding,
   headerContentType,
   headerTimeout,
-} from "@bufbuild/connect-core/protocol-grpc";
-import {
   parseContentType,
   trailerFlag,
   trailerSerialize,


### PR DESCRIPTION
This fixes bugs in `grpcWebCreateRequestHeaderWithCompression()` and `grpcCreateRequestHeaderWithCompression()`. 

It makes uses of the header name consts added in https://github.com/bufbuild/connect-web/pull/411.