### PR TITLE
Update transform streams

### DIFF
--- a/packages/connect-core/src/index.ts
+++ b/packages/connect-core/src/index.ts
@@ -55,12 +55,11 @@ export {
 } from "./envelope.js";
 export { Compression, compressedFlag } from "./compression.js";
 export {
+  ParsedEnvelopedMessage,
   transformCompress,
   transformDecompress,
   transformJoin,
   transformSplit,
   transformSerialize,
   transformParse,
-  transformSerializeWithEnd,
-  transformParseWithEnd,
 } from "./transform-stream.js";

--- a/packages/connect-core/src/protocol-connect/index.ts
+++ b/packages/connect-core/src/protocol-connect/index.ts
@@ -21,6 +21,7 @@ export {
   endStreamToJson,
   endStreamFromJson,
   endStreamFlag,
+  createEndStreamSerialization,
 } from "./end-stream.js";
 export { errorFromJson } from "./error-from-json.js";
 export { errorToJson } from "./error-to-json.js";

--- a/packages/connect-core/src/protocol-grpc-web/index.ts
+++ b/packages/connect-core/src/protocol-grpc-web/index.ts
@@ -21,7 +21,12 @@ export {
   validateResponse,
   validateResponseWithCompression,
 } from "./validate-response.js";
-export { trailerFlag, trailerParse, trailerSerialize } from "./trailer.js";
+export {
+  trailerFlag,
+  trailerParse,
+  trailerSerialize,
+  createTrailerSerialization,
+} from "./trailer.js";
 export * from "./headers.js";
 export {
   parseTimeout,

--- a/packages/connect-core/src/protocol-grpc-web/trailer.ts
+++ b/packages/connect-core/src/protocol-grpc-web/trailer.ts
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import type { Serialization } from "../serialization.js";
+
 /**
  * trailerFlag indicates that the data in a EnvelopedMessage
  * is a set of trailers of the gRPC-web protocol.
@@ -47,4 +49,15 @@ export function trailerSerialize(trailer: Headers): Uint8Array {
     lines.push(`${key}: ${value}\r\n`);
   });
   return new TextEncoder().encode(lines.join(""));
+}
+
+/**
+ * Create a Serialization object that serializes a gRPC-web trailer, a Headers
+ * object that is serialized as a set of header fields, separated by CRLF.
+ */
+export function createTrailerSerialization(): Serialization<Headers> {
+  return {
+    serialize: trailerSerialize,
+    parse: trailerParse,
+  };
 }

--- a/packages/connect-core/src/transform-stream-story.spec.ts
+++ b/packages/connect-core/src/transform-stream-story.spec.ts
@@ -24,8 +24,8 @@ import {
   transformCompress,
   transformDecompress,
   transformJoin,
-  transformParseWithEnd,
-  transformSerializeWithEnd,
+  transformParse,
+  transformSerialize,
   transformSplit,
 } from "./transform-stream.js";
 import type { Compression } from "./compression.js";
@@ -111,7 +111,7 @@ describe("full story", function () {
     it("should write expected bytes", async function () {
       const stream = createReadableStream(goldenPayload)
         .pipeThrough(
-          transformSerializeWithEnd(serialization, endSerialization, endFlag),
+          transformSerialize(serialization, endFlag, endSerialization),
           {}
         )
         .pipeThrough(
@@ -130,7 +130,7 @@ describe("full story", function () {
         .pipeThrough(transformSplit(readMaxBytes), {})
         .pipeThrough(transformDecompress(compressionReverse, readMaxBytes), {})
         .pipeThrough(
-          transformParseWithEnd(serialization, endSerialization, endFlag),
+          transformParse(serialization, endFlag, endSerialization),
           {}
         );
       const all = await readAll(inputStream);
@@ -147,7 +147,7 @@ describe("full story", function () {
       const requestWriter = requestTransformStream.writable.getWriter();
       const rawRequestStream = requestTransformStream.readable
         .pipeThrough(
-          transformSerializeWithEnd(serialization, endSerialization, endFlag),
+          transformSerialize(serialization, endFlag, endSerialization),
           {}
         )
         .pipeThrough(
@@ -160,7 +160,7 @@ describe("full story", function () {
         .pipeThrough(transformSplit(readMaxBytes), {})
         .pipeThrough(transformDecompress(compressionReverse, readMaxBytes), {})
         .pipeThrough(
-          transformParseWithEnd(serialization, endSerialization, endFlag),
+          transformParse(serialization, endFlag, endSerialization),
           {}
         )
         .getReader();
@@ -250,7 +250,7 @@ describe("full story", function () {
         .pipeThrough(transformSplit(readMaxBytes), {})
         .pipeThrough(transformDecompress(compressionReverse, readMaxBytes), {})
         .pipeThrough(
-          transformParseWithEnd(serialization, endSerialization, endFlag),
+          transformParse(serialization, endFlag, endSerialization),
           {}
         );
 
@@ -305,7 +305,7 @@ describe("full story", function () {
         },
       })
         .pipeThrough(
-          transformSerializeWithEnd(serialization, endSerialization, endFlag),
+          transformSerialize(serialization, endFlag, endSerialization),
           {}
         )
         .pipeThrough(

--- a/packages/connect-web-bench/README.md
+++ b/packages/connect-web-bench/README.md
@@ -10,6 +10,6 @@ it like a web server would usually do.
 
 | code generator | bundle size        | minified               | compressed           |
 |----------------|-------------------:|-----------------------:|---------------------:|
-| connect-web    | 102,763 b | 43,942 b | 12,066 b |
+| connect-web    | 102,761 b | 43,942 b | 12,070 b |
 | connect-web (legacy) | 94,850 b | 40,976 b | 11,358 b |
 | grpc-web       | 414,222 b    | 301,127 b    | 53,226 b |


### PR DESCRIPTION
This makes adds overrides to transformSerialize() and transformParse(), joining the functionality of the variants with support for end-of-stream messages.

This adds a feature: If the "endSerialization" argument is null, the transform raises an error if the end-stream flag is set.

This adds Serialization objects for gRPC-web trailers and Connect's EndStreamResponse.