### PR TITLE
Add asynchronous iterable transforms

### DIFF
--- a/packages/connect-core/src/envelope.spec.ts
+++ b/packages/connect-core/src/envelope.spec.ts
@@ -205,7 +205,7 @@ describe("envelope compression", function () {
         } catch (e) {
           expect(e).toBeInstanceOf(ConnectError);
           expect(connectErrorFromReason(e).message).toBe(
-            "[invalid_argument] received compressed envelope, but do not now how to decompress"
+            "[invalid_argument] received compressed envelope, but do not know how to decompress"
           );
         }
       });

--- a/packages/connect-core/src/envelope.spec.ts
+++ b/packages/connect-core/src/envelope.spec.ts
@@ -12,8 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { createEnvelopeReadableStream, encodeEnvelopes } from "./envelope.js";
+import {
+  createEnvelopeReadableStream,
+  encodeEnvelopes,
+  envelopeCompress,
+  envelopeDecompress,
+  EnvelopedMessage,
+} from "./envelope.js";
 import { createReadableByteStream } from "./whatwg-stream-helper.spec.js";
+import type { Compression } from "./compression.js";
+import { ConnectError, connectErrorFromReason } from "./connect-error.js";
+import { Code } from "./code.js";
 
 describe("createEnvelopeReadableStream()", () => {
   it("reads empty stream", async () => {
@@ -115,5 +124,170 @@ describe("createEnvelopeReadableStream()", () => {
     }
     const r = await reader.read();
     expect(r.done).toBeTrue();
+  });
+});
+
+describe("envelope compression", function () {
+  const compressionReverse: Compression = {
+    name: "fake",
+    compress(bytes) {
+      const b = new Uint8Array(bytes.byteLength);
+      b.set(bytes, 0);
+      return Promise.resolve(b.reverse());
+    },
+    decompress(bytes, readMaxBytes) {
+      if (bytes.byteLength > readMaxBytes) {
+        return Promise.reject(
+          new ConnectError(
+            `message is larger than configured readMaxBytes ${readMaxBytes} after decompression`,
+            Code.ResourceExhausted
+          )
+        );
+      }
+      const b = new Uint8Array(bytes.byteLength);
+      b.set(bytes, 0);
+      return Promise.resolve(b.reverse());
+    },
+  };
+  const uncompressedEnvelope: EnvelopedMessage = {
+    flags: 0,
+    data: new Uint8Array([0xde, 0xad, 0xbe, 0xe1]),
+  };
+  const compressedEnvelope: EnvelopedMessage = {
+    flags: 0 | 0b00000001,
+    data: new Uint8Array([0xde, 0xad, 0xbe, 0xe1].reverse()),
+  };
+  describe("envelopeDecompress()", function () {
+    it("should decompress envelopes", async function () {
+      const got = await envelopeDecompress(
+        compressedEnvelope,
+        compressionReverse,
+        Number.MAX_SAFE_INTEGER
+      );
+      expect(got).toEqual(uncompressedEnvelope);
+    });
+    it("should not decompress uncompressed envelopes", async function () {
+      const got = await envelopeDecompress(
+        uncompressedEnvelope,
+        compressionReverse,
+        Number.MAX_SAFE_INTEGER
+      );
+      expect(got).toEqual(uncompressedEnvelope);
+    });
+    it("should pass readMaxBytes to compression", async function () {
+      try {
+        await envelopeDecompress(compressedEnvelope, compressionReverse, 3);
+        fail("expected error");
+      } catch (e) {
+        expect(e).toBeInstanceOf(ConnectError);
+        expect(connectErrorFromReason(e).message).toBe(
+          "[resource_exhausted] message is larger than configured readMaxBytes 3 after decompression"
+        );
+      }
+    });
+    describe("with null compression", function () {
+      it("should not decompress uncompressed envelopes", async function () {
+        const got = await envelopeDecompress(
+          uncompressedEnvelope,
+          null,
+          Number.MAX_SAFE_INTEGER
+        );
+        expect(got).toEqual(uncompressedEnvelope);
+      });
+      it("should raise error on compressed envelope", async function () {
+        try {
+          await envelopeDecompress(
+            compressedEnvelope,
+            null,
+            Number.MAX_SAFE_INTEGER
+          );
+          fail("expected error");
+        } catch (e) {
+          expect(e).toBeInstanceOf(ConnectError);
+          expect(connectErrorFromReason(e).message).toBe(
+            "[invalid_argument] received compressed envelope, but do not now how to decompress"
+          );
+        }
+      });
+      it("should honor readMaxBytes", async function () {
+        try {
+          await envelopeDecompress(uncompressedEnvelope, null, 3);
+          fail("expected error");
+        } catch (e) {
+          expect(e).toBeInstanceOf(ConnectError);
+          expect(connectErrorFromReason(e).message).toBe(
+            "[resource_exhausted] message size 4 is larger than configured readMaxBytes 3"
+          );
+        }
+      });
+    });
+  });
+
+  describe("envelopeCompress()", function () {
+    it("should compress uncompressed envelope", async function () {
+      const got = await envelopeCompress(
+        uncompressedEnvelope,
+        compressionReverse,
+        Number.MAX_SAFE_INTEGER,
+        0
+      );
+      expect(got).toEqual(compressedEnvelope);
+    });
+    it("should compress uncompressed envelope", async function () {
+      const got = await envelopeCompress(
+        uncompressedEnvelope,
+        compressionReverse,
+        Number.MAX_SAFE_INTEGER,
+        0
+      );
+      expect(got).toEqual(compressedEnvelope);
+    });
+    it("should throw on compressed input", async function () {
+      try {
+        await envelopeCompress(
+          compressedEnvelope,
+          compressionReverse,
+          Number.MAX_SAFE_INTEGER,
+          0
+        );
+        fail("expected error");
+      } catch (e) {
+        expect(e).toBeInstanceOf(ConnectError);
+        expect(connectErrorFromReason(e).message).toBe(
+          "[internal] invalid envelope, already compressed"
+        );
+      }
+    });
+    it("should honor compressMinBytes", async function () {
+      const got = await envelopeCompress(
+        uncompressedEnvelope,
+        null,
+        Number.MAX_SAFE_INTEGER,
+        5
+      );
+      expect(got).toEqual(uncompressedEnvelope);
+    });
+    describe("with null compression", function () {
+      it("should not compress", async function () {
+        const got = await envelopeCompress(
+          uncompressedEnvelope,
+          null,
+          Number.MAX_SAFE_INTEGER,
+          0
+        );
+        expect(got).toEqual(uncompressedEnvelope);
+      });
+      it("should honor writeMaxBytes", async function () {
+        try {
+          await envelopeCompress(uncompressedEnvelope, null, 3, 0);
+          fail("expected error");
+        } catch (e) {
+          expect(e).toBeInstanceOf(ConnectError);
+          expect(connectErrorFromReason(e).message).toBe(
+            "[resource_exhausted] message size 4 is larger than configured writeMaxBytes 3"
+          );
+        }
+      });
+    });
   });
 });

--- a/packages/connect-core/src/envelope.ts
+++ b/packages/connect-core/src/envelope.ts
@@ -153,7 +153,7 @@ export async function envelopeDecompress(
   if ((flags & compressedFlag) === compressedFlag) {
     if (!compression) {
       throw new ConnectError(
-        "received compressed envelope, but do not now how to decompress",
+        "received compressed envelope, but do not know how to decompress",
         Code.InvalidArgument
       );
     }

--- a/packages/connect-core/src/index.ts
+++ b/packages/connect-core/src/index.ts
@@ -45,21 +45,35 @@ export {
   Serialization,
   createBinarySerialization,
   createJsonSerialization,
+  createMethodSerializationLookup,
   createClientMethodSerializers,
 } from "./serialization.js";
 export {
   createEnvelopeReadableStream,
   EnvelopedMessage,
+  ParsedEnvelopedMessage,
   encodeEnvelope,
   encodeEnvelopes,
+  envelopeDecompress,
+  envelopeCompress,
 } from "./envelope.js";
 export { Compression, compressedFlag } from "./compression.js";
 export {
-  ParsedEnvelopedMessage,
+  streamTransformCompress,
+  streamTransformDecompress,
+  streamTransformJoin,
+  streamTransformSplit,
+  streamTransformSerialize,
+  streamTransformParse,
+} from "./stream-transform.js";
+export {
+  AsyncIterableTransformer,
+  transformAsyncIterable,
   transformCompress,
   transformDecompress,
   transformJoin,
   transformSplit,
   transformSerialize,
   transformParse,
-} from "./transform-stream.js";
+  transformCatch,
+} from "./transform-iterable.js";

--- a/packages/connect-core/src/protocol-grpc/trailer-status.ts
+++ b/packages/connect-core/src/protocol-grpc/trailer-status.ts
@@ -32,7 +32,7 @@ const fieldGrpcStatusDetailsBin = "grpc-status-details-bin",
 export function setTrailerStatus(
   target: Headers,
   error: ConnectError | undefined
-): void {
+): Headers {
   if (error) {
     target.set(fieldGrpcStatus, error.code.toString(10));
     target.set(fieldGrpcMessage, encodeURIComponent(error.rawMessage));
@@ -54,6 +54,7 @@ export function setTrailerStatus(
   } else {
     target.set(fieldGrpcStatus, "0");
   }
+  return target;
 }
 
 /**

--- a/packages/connect-core/src/serialization.ts
+++ b/packages/connect-core/src/serialization.ts
@@ -111,6 +111,50 @@ export function createJsonSerialization<T extends Message<T>>(
 }
 
 /**
+ * Create an object that provides convenient access to request and response
+ * message serialization for a given method.
+ */
+export function createMethodSerializationLookup<
+  I extends Message<I>,
+  O extends Message<O>
+>(
+  method: MethodInfo<I, O>,
+  binaryOptions: Partial<BinaryReadOptions & BinaryWriteOptions> | undefined,
+  jsonOptions: Partial<JsonReadOptions & JsonWriteOptions> | undefined
+): MethodSerializationLookup<I, O> {
+  const inputBinary = createBinarySerialization(method.I, binaryOptions);
+  const inputJson = createJsonSerialization(method.I, jsonOptions);
+  const outputBinary = createBinarySerialization(method.O, binaryOptions);
+  const outputJson = createJsonSerialization(method.O, jsonOptions);
+  return {
+    getI(useBinaryFormat) {
+      return useBinaryFormat ? inputBinary : inputJson;
+    },
+    getO(useBinaryFormat) {
+      return useBinaryFormat ? outputBinary : outputJson;
+    },
+  };
+}
+
+/**
+ * MethodSerializationLookup provides convenient access to request and response
+ * message serialization for a given method.
+ */
+interface MethodSerializationLookup<
+  I extends Message<I>,
+  O extends Message<O>
+> {
+  /**
+   * Get the JSON or binary serialization for the request message type.
+   */
+  getI(useBinaryFormat: boolean): Serialization<I>;
+  /**
+   * Get the JSON or binary serialization for the response message type.
+   */
+  getO(useBinaryFormat: boolean): Serialization<O>;
+}
+
+/**
  * Returns functions to normalize and serialize the input message
  * of an RPC, and to parse the output message of an RPC.
  */

--- a/packages/connect-core/src/stream-transform-story.spec.ts
+++ b/packages/connect-core/src/stream-transform-story.spec.ts
@@ -1,0 +1,333 @@
+// Copyright 2021-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  createReadableByteStream,
+  createReadableStream,
+  node16WhatwgStreamPolyfill,
+  readAll,
+  readAllBytes,
+} from "./whatwg-stream-helper.spec.js";
+import type { Serialization } from "./serialization.js";
+import {
+  streamTransformCompress,
+  streamTransformDecompress,
+  streamTransformJoin,
+  streamTransformParse,
+  streamTransformSerialize,
+  streamTransformSplit,
+} from "./stream-transform.js";
+import type { Compression } from "./compression.js";
+import { encodeEnvelopes } from "./envelope.js";
+import { ConnectError } from "./connect-error.js";
+import { Code } from "./code.js";
+
+node16WhatwgStreamPolyfill();
+
+// These tests aim to model the usage of transform streams in clients and servers.
+// Note that the tests were written as a proof of concept, and the coverage is
+// incomplete (cancellation, backpressure, error handling, etc.).
+describe("full story", function () {
+  const readMaxBytes = 0xffffffff; // zlib caps maxOutputLength at this value
+  const writeMaxBytes = readMaxBytes;
+  const serialization: Serialization<string> = {
+    serialize(data: string): Uint8Array {
+      return new TextEncoder().encode(data);
+    },
+    parse(data: Uint8Array): string {
+      return new TextDecoder().decode(data);
+    },
+  };
+  const endSerialization: Serialization<"end"> = {
+    serialize(data: string): Uint8Array {
+      return new TextEncoder().encode(data + ".");
+    },
+    parse(data: Uint8Array): "end" {
+      const t = new TextDecoder().decode(data).slice(0, -1);
+      if (t !== "end") {
+        throw new ConnectError(
+          "serialize end: cannot parse",
+          Code.InvalidArgument
+        );
+      }
+      return t;
+    },
+  };
+  const endFlag = 0b10000000;
+  const compressionReverse: Compression = {
+    name: "fake",
+    compress(bytes) {
+      const b = new Uint8Array(bytes.byteLength);
+      b.set(bytes, 0);
+      return Promise.resolve(b.reverse());
+    },
+    decompress(bytes, readMaxBytes) {
+      if (bytes.byteLength > readMaxBytes) {
+        return Promise.reject(
+          new ConnectError(
+            `message is larger than configured readMaxBytes ${readMaxBytes} after decompression`,
+            Code.ResourceExhausted
+          )
+        );
+      }
+      const b = new Uint8Array(bytes.byteLength);
+      b.set(bytes, 0);
+      return Promise.resolve(b.reverse());
+    },
+  };
+  const goldenBytes = encodeEnvelopes(
+    {
+      flags: 0 | 0b00000001,
+      data: new TextEncoder().encode("alpha").reverse(),
+    },
+    {
+      flags: 0 | 0b00000001,
+      data: new TextEncoder().encode("beta").reverse(),
+    },
+    {
+      flags: 0 | 0b00000001 | endFlag,
+      data: new TextEncoder().encode("end.").reverse(),
+    }
+  );
+  type Payload<I, E> = { end: false; value: I } | { end: true; value: E };
+  const goldenPayload: Payload<string, "end">[] = [
+    { value: "alpha", end: false },
+    { value: "beta", end: false },
+    { value: "end", end: true },
+  ];
+
+  describe("write", function () {
+    it("should write expected bytes", async function () {
+      const stream = createReadableStream(goldenPayload)
+        .pipeThrough(
+          streamTransformSerialize(serialization, endFlag, endSerialization),
+          {}
+        )
+        .pipeThrough(
+          streamTransformCompress(compressionReverse, writeMaxBytes, 0),
+          {}
+        )
+        .pipeThrough(streamTransformJoin(writeMaxBytes), {});
+      const all = await readAllBytes(stream);
+      expect(all).toEqual(goldenBytes);
+    });
+  });
+
+  describe("read", function () {
+    it("should read expected bytes", async function () {
+      const inputStream = createReadableByteStream(goldenBytes)
+        .pipeThrough(streamTransformSplit(readMaxBytes), {})
+        .pipeThrough(
+          streamTransformDecompress(compressionReverse, readMaxBytes),
+          {}
+        )
+        .pipeThrough(
+          streamTransformParse(serialization, endFlag, endSerialization),
+          {}
+        );
+      const all = await readAll(inputStream);
+      expect(all).toEqual(goldenPayload);
+    });
+  });
+
+  describe("client integration", function () {
+    it("should works", async function () {
+      const requestTransformStream = new TransformStream<
+        { end: false; value: string } | { end: true; value: "end" },
+        { end: false; value: string } | { end: true; value: "end" }
+      >();
+      const requestWriter = requestTransformStream.writable.getWriter();
+      const rawRequestStream = requestTransformStream.readable
+        .pipeThrough(
+          streamTransformSerialize(serialization, endFlag, endSerialization),
+          {}
+        )
+        .pipeThrough(
+          streamTransformCompress(compressionReverse, writeMaxBytes, 0),
+          {}
+        )
+        .pipeThrough(streamTransformJoin(writeMaxBytes), {});
+
+      const responseReader = createReadableByteStream(goldenBytes)
+        .pipeThrough(streamTransformSplit(readMaxBytes), {})
+        .pipeThrough(
+          streamTransformDecompress(compressionReverse, readMaxBytes),
+          {}
+        )
+        .pipeThrough(
+          streamTransformParse(serialization, endFlag, endSerialization),
+          {}
+        )
+        .getReader();
+
+      const streamingConn = {
+        async send(message: string): Promise<void> {
+          await requestWriter.ready;
+          await requestWriter.write({
+            end: false,
+            value: message,
+          });
+        },
+        async close(): Promise<void> {
+          await requestWriter.ready;
+          await requestWriter.write({
+            end: true,
+            value: "end",
+          });
+          await requestWriter.close();
+        },
+        async read(): Promise<ReadableStreamReadResult<string>> {
+          const r = await responseReader.read();
+          if (r.done) {
+            return {
+              done: true,
+              value: undefined,
+            };
+          }
+          if (r.value.end) {
+            return {
+              done: true,
+              value: undefined,
+            };
+          }
+          return {
+            done: false,
+            value: r.value.value,
+          };
+        },
+      };
+
+      const writtenBytesPromise = readAllBytes(rawRequestStream);
+
+      await streamingConn.send("alpha");
+      await streamingConn.send("beta");
+      await streamingConn.close();
+
+      const alpha = await streamingConn.read();
+      expect(alpha).toEqual({
+        done: false,
+        value: "alpha",
+      });
+      const beta = await streamingConn.read();
+      expect(beta).toEqual({
+        done: false,
+        value: "beta",
+      });
+      const end = await streamingConn.read();
+      expect(end).toEqual({
+        done: true,
+        value: undefined,
+      });
+
+      const writtenBytes = await writtenBytesPromise;
+      expect(writtenBytes).toEqual(goldenBytes);
+    });
+  });
+
+  describe("server integration", function () {
+    const echoImplReceived: string[] = [];
+
+    async function* echoImpl(
+      input: AsyncIterable<string>
+    ): AsyncIterable<string> {
+      for await (const i of input) {
+        echoImplReceived.push(i);
+        yield i;
+      }
+    }
+
+    beforeEach(function () {
+      echoImplReceived.splice(0);
+    });
+
+    it("should echo expected bytes", async function () {
+      const requestStream = createReadableByteStream(goldenBytes)
+        .pipeThrough(streamTransformSplit(readMaxBytes), {})
+        .pipeThrough(
+          streamTransformDecompress(compressionReverse, readMaxBytes),
+          {}
+        )
+        .pipeThrough(
+          streamTransformParse(serialization, endFlag, endSerialization),
+          {}
+        );
+
+      // implementations take an iterable - make our stream available as one
+      const implInput: AsyncIterable<string> = {
+        [Symbol.asyncIterator](): AsyncIterator<string> {
+          const reader = requestStream.getReader();
+          return {
+            async next(): Promise<IteratorResult<string>> {
+              const r = await reader.read();
+              if (r.done) {
+                return {
+                  done: true,
+                  value: undefined,
+                };
+              }
+              if (r.value.end) {
+                return {
+                  done: true,
+                  value: undefined,
+                };
+              }
+              return {
+                done: false,
+                value: r.value.value,
+              };
+            },
+          };
+        },
+      };
+
+      // invoke the implementation
+      const implOutput = echoImpl(implInput)[Symbol.asyncIterator]();
+
+      // implementations return an iterable - make a readable stream from it
+      const responseStream = new ReadableStream<
+        { end: false; value: string } | { end: true; value: string }
+      >({
+        async pull(controller) {
+          const r = await implOutput.next();
+          if (r.done === true) {
+            controller.enqueue({
+              end: true,
+              value: "end",
+            });
+            return controller.close();
+          }
+          controller.enqueue({
+            end: false,
+            value: r.value,
+          });
+        },
+      })
+        .pipeThrough(
+          streamTransformSerialize(serialization, endFlag, endSerialization),
+          {}
+        )
+        .pipeThrough(
+          streamTransformCompress(compressionReverse, writeMaxBytes, 0),
+          {}
+        )
+        .pipeThrough(streamTransformJoin(writeMaxBytes), {});
+
+      // in practice, we would pipe the response data to a writable stream with pipeTo()
+      expect(await readAllBytes(responseStream)).toEqual(goldenBytes);
+
+      // sanity check that the implementation was invoked
+      expect(echoImplReceived).toEqual(["alpha", "beta"]);
+    });
+  });
+});

--- a/packages/connect-core/src/stream-transform.spec.ts
+++ b/packages/connect-core/src/stream-transform.spec.ts
@@ -1,0 +1,333 @@
+// Copyright 2021-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  createReadableByteStream,
+  createReadableStream,
+  node16WhatwgStreamPolyfill,
+  readAll,
+  readAllBytes,
+} from "./whatwg-stream-helper.spec.js";
+import type { Serialization } from "./serialization.js";
+import {
+  streamTransformCompress,
+  streamTransformDecompress,
+  streamTransformJoin,
+  streamTransformParse,
+  streamTransformSerialize,
+  streamTransformSplit,
+} from "./stream-transform.js";
+import type { Compression } from "./compression.js";
+import { encodeEnvelopes } from "./envelope.js";
+import { ConnectError } from "./connect-error.js";
+import { Code } from "./code.js";
+
+node16WhatwgStreamPolyfill();
+
+// These tests aim to model the usage of transform streams in clients and servers.
+// Note that the tests were written as a proof of concept, and the coverage is
+// incomplete (cancellation, backpressure, error handling, etc.).
+describe("full story", function () {
+  const readMaxBytes = 0xffffffff; // zlib caps maxOutputLength at this value
+  const writeMaxBytes = readMaxBytes;
+  const serialization: Serialization<string> = {
+    serialize(data: string): Uint8Array {
+      return new TextEncoder().encode(data);
+    },
+    parse(data: Uint8Array): string {
+      return new TextDecoder().decode(data);
+    },
+  };
+  const endSerialization: Serialization<"end"> = {
+    serialize(data: string): Uint8Array {
+      return new TextEncoder().encode(data + ".");
+    },
+    parse(data: Uint8Array): "end" {
+      const t = new TextDecoder().decode(data).slice(0, -1);
+      if (t !== "end") {
+        throw new ConnectError(
+          "serialize end: cannot parse",
+          Code.InvalidArgument
+        );
+      }
+      return t;
+    },
+  };
+  const endFlag = 0b10000000;
+  const compressionReverse: Compression = {
+    name: "fake",
+    compress(bytes) {
+      const b = new Uint8Array(bytes.byteLength);
+      b.set(bytes, 0);
+      return Promise.resolve(b.reverse());
+    },
+    decompress(bytes, readMaxBytes) {
+      if (bytes.byteLength > readMaxBytes) {
+        return Promise.reject(
+          new ConnectError(
+            `message is larger than configured readMaxBytes ${readMaxBytes} after decompression`,
+            Code.ResourceExhausted
+          )
+        );
+      }
+      const b = new Uint8Array(bytes.byteLength);
+      b.set(bytes, 0);
+      return Promise.resolve(b.reverse());
+    },
+  };
+  const goldenBytes = encodeEnvelopes(
+    {
+      flags: 0 | 0b00000001,
+      data: new TextEncoder().encode("alpha").reverse(),
+    },
+    {
+      flags: 0 | 0b00000001,
+      data: new TextEncoder().encode("beta").reverse(),
+    },
+    {
+      flags: 0 | 0b00000001 | endFlag,
+      data: new TextEncoder().encode("end.").reverse(),
+    }
+  );
+  type Payload<I, E> = { end: false; value: I } | { end: true; value: E };
+  const goldenPayload: Payload<string, "end">[] = [
+    { value: "alpha", end: false },
+    { value: "beta", end: false },
+    { value: "end", end: true },
+  ];
+
+  describe("write", function () {
+    it("should write expected bytes", async function () {
+      const stream = createReadableStream(goldenPayload)
+        .pipeThrough(
+          streamTransformSerialize(serialization, endFlag, endSerialization),
+          {}
+        )
+        .pipeThrough(
+          streamTransformCompress(compressionReverse, writeMaxBytes, 0),
+          {}
+        )
+        .pipeThrough(streamTransformJoin(writeMaxBytes), {});
+      const all = await readAllBytes(stream);
+      expect(all).toEqual(goldenBytes);
+    });
+  });
+
+  describe("read", function () {
+    it("should read expected bytes", async function () {
+      const inputStream = createReadableByteStream(goldenBytes)
+        .pipeThrough(streamTransformSplit(readMaxBytes), {})
+        .pipeThrough(
+          streamTransformDecompress(compressionReverse, readMaxBytes),
+          {}
+        )
+        .pipeThrough(
+          streamTransformParse(serialization, endFlag, endSerialization),
+          {}
+        );
+      const all = await readAll(inputStream);
+      expect(all).toEqual(goldenPayload);
+    });
+  });
+
+  describe("client integration", function () {
+    it("should works", async function () {
+      const requestTransformStream = new TransformStream<
+        { end: false; value: string } | { end: true; value: "end" },
+        { end: false; value: string } | { end: true; value: "end" }
+      >();
+      const requestWriter = requestTransformStream.writable.getWriter();
+      const rawRequestStream = requestTransformStream.readable
+        .pipeThrough(
+          streamTransformSerialize(serialization, endFlag, endSerialization),
+          {}
+        )
+        .pipeThrough(
+          streamTransformCompress(compressionReverse, writeMaxBytes, 0),
+          {}
+        )
+        .pipeThrough(streamTransformJoin(writeMaxBytes), {});
+
+      const responseReader = createReadableByteStream(goldenBytes)
+        .pipeThrough(streamTransformSplit(readMaxBytes), {})
+        .pipeThrough(
+          streamTransformDecompress(compressionReverse, readMaxBytes),
+          {}
+        )
+        .pipeThrough(
+          streamTransformParse(serialization, endFlag, endSerialization),
+          {}
+        )
+        .getReader();
+
+      const streamingConn = {
+        async send(message: string): Promise<void> {
+          await requestWriter.ready;
+          await requestWriter.write({
+            end: false,
+            value: message,
+          });
+        },
+        async close(): Promise<void> {
+          await requestWriter.ready;
+          await requestWriter.write({
+            end: true,
+            value: "end",
+          });
+          await requestWriter.close();
+        },
+        async read(): Promise<ReadableStreamReadResult<string>> {
+          const r = await responseReader.read();
+          if (r.done) {
+            return {
+              done: true,
+              value: undefined,
+            };
+          }
+          if (r.value.end) {
+            return {
+              done: true,
+              value: undefined,
+            };
+          }
+          return {
+            done: false,
+            value: r.value.value,
+          };
+        },
+      };
+
+      const writtenBytesPromise = readAllBytes(rawRequestStream);
+
+      await streamingConn.send("alpha");
+      await streamingConn.send("beta");
+      await streamingConn.close();
+
+      const alpha = await streamingConn.read();
+      expect(alpha).toEqual({
+        done: false,
+        value: "alpha",
+      });
+      const beta = await streamingConn.read();
+      expect(beta).toEqual({
+        done: false,
+        value: "beta",
+      });
+      const end = await streamingConn.read();
+      expect(end).toEqual({
+        done: true,
+        value: undefined,
+      });
+
+      const writtenBytes = await writtenBytesPromise;
+      expect(writtenBytes).toEqual(goldenBytes);
+    });
+  });
+
+  describe("server integration", function () {
+    const echoImplReceived: string[] = [];
+
+    async function* echoImpl(
+      input: AsyncIterable<string>
+    ): AsyncIterable<string> {
+      for await (const i of input) {
+        echoImplReceived.push(i);
+        yield i;
+      }
+    }
+
+    beforeEach(function () {
+      echoImplReceived.splice(0);
+    });
+
+    it("should echo expected bytes", async function () {
+      const requestStream = createReadableByteStream(goldenBytes)
+        .pipeThrough(streamTransformSplit(readMaxBytes), {})
+        .pipeThrough(
+          streamTransformDecompress(compressionReverse, readMaxBytes),
+          {}
+        )
+        .pipeThrough(
+          streamTransformParse(serialization, endFlag, endSerialization),
+          {}
+        );
+
+      // implementations take an iterable - make our stream available as one
+      const implInput: AsyncIterable<string> = {
+        [Symbol.asyncIterator](): AsyncIterator<string> {
+          const reader = requestStream.getReader();
+          return {
+            async next(): Promise<IteratorResult<string>> {
+              const r = await reader.read();
+              if (r.done) {
+                return {
+                  done: true,
+                  value: undefined,
+                };
+              }
+              if (r.value.end) {
+                return {
+                  done: true,
+                  value: undefined,
+                };
+              }
+              return {
+                done: false,
+                value: r.value.value,
+              };
+            },
+          };
+        },
+      };
+
+      // invoke the implementation
+      const implOutput = echoImpl(implInput)[Symbol.asyncIterator]();
+
+      // implementations return an iterable - make a readable stream from it
+      const responseStream = new ReadableStream<
+        { end: false; value: string } | { end: true; value: string }
+      >({
+        async pull(controller) {
+          const r = await implOutput.next();
+          if (r.done === true) {
+            controller.enqueue({
+              end: true,
+              value: "end",
+            });
+            return controller.close();
+          }
+          controller.enqueue({
+            end: false,
+            value: r.value,
+          });
+        },
+      })
+        .pipeThrough(
+          streamTransformSerialize(serialization, endFlag, endSerialization),
+          {}
+        )
+        .pipeThrough(
+          streamTransformCompress(compressionReverse, writeMaxBytes, 0),
+          {}
+        )
+        .pipeThrough(streamTransformJoin(writeMaxBytes), {});
+
+      // in practice, we would pipe the response data to a writable stream with pipeTo()
+      expect(await readAllBytes(responseStream)).toEqual(goldenBytes);
+
+      // sanity check that the implementation was invoked
+      expect(echoImplReceived).toEqual(["alpha", "beta"]);
+    });
+  });
+});

--- a/packages/connect-core/src/transform-iterable-helper.spec.ts
+++ b/packages/connect-core/src/transform-iterable-helper.spec.ts
@@ -1,0 +1,56 @@
+// Copyright 2021-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// eslint-disable-next-line @typescript-eslint/require-await
+export async function* createAsyncIterable<T>(items: T[]): AsyncIterable<T> {
+  for (const item of items) {
+    yield item;
+  }
+}
+
+export async function* createAsyncIterableBytes(
+  bytes: Uint8Array,
+  chunkSize = 2,
+  delay = 5
+): AsyncIterable<Uint8Array> {
+  let offset = 0;
+  for (;;) {
+    await new Promise((resolve) => setTimeout(resolve, delay));
+    const end = Math.min(offset + chunkSize, bytes.byteLength);
+    yield bytes.slice(offset, end);
+    offset = end;
+    if (offset === bytes.length) {
+      break;
+    }
+  }
+}
+
+export async function readAll<T>(it: AsyncIterable<T>): Promise<T[]> {
+  const all: T[] = [];
+  for await (const item of it) {
+    all.push(item);
+  }
+  return all;
+}
+
+export async function readAllBytes(
+  it: AsyncIterable<Uint8Array>
+): Promise<Uint8Array> {
+  return (await readAll(it)).reduce((p, c) => {
+    const n = new Uint8Array(p.byteLength + c.byteLength);
+    n.set(p, 0);
+    n.set(c, p.byteLength);
+    return n;
+  }, new Uint8Array(0));
+}

--- a/packages/connect-core/src/transform-iterable.spec.ts
+++ b/packages/connect-core/src/transform-iterable.spec.ts
@@ -447,7 +447,7 @@ describe("transforming asynchronous iterables", () => {
           } catch (e) {
             expect(e).toBeInstanceOf(ConnectError);
             expect(connectErrorFromReason(e).message).toBe(
-              "[invalid_argument] received compressed envelope, but do not now how to decompress"
+              "[invalid_argument] received compressed envelope, but do not know how to decompress"
             );
           }
         });

--- a/packages/connect-core/src/transform-iterable.spec.ts
+++ b/packages/connect-core/src/transform-iterable.spec.ts
@@ -13,29 +13,28 @@
 // limitations under the License.
 
 import {
+  transformAsyncIterable,
+  transformCatch,
   transformCompress,
   transformDecompress,
   transformJoin,
   transformParse,
   transformSerialize,
   transformSplit,
-} from "./transform-stream.js";
-import type { Compression } from "./compression.js";
+} from "./transform-iterable.js";
 import type { Serialization } from "./serialization.js";
-import type { EnvelopedMessage } from "./envelope.js";
-import { ConnectError, connectErrorFromReason } from "./connect-error.js";
-import { Code } from "./code.js";
 import {
-  createReadableByteStream,
-  createReadableStream,
-  node16WhatwgStreamPolyfill,
+  createAsyncIterable,
+  createAsyncIterableBytes,
   readAll,
   readAllBytes,
-} from "./whatwg-stream-helper.spec.js";
+} from "./transform-iterable-helper.spec.js";
+import { ConnectError, connectErrorFromReason } from "./connect-error.js";
+import { Code } from "./code.js";
+import type { EnvelopedMessage } from "./envelope.js";
+import type { Compression } from "./compression.js";
 
-node16WhatwgStreamPolyfill();
-
-describe("transforming WHATWG streams", () => {
+describe("transforming asynchronous iterables", () => {
   describe("serialization", function () {
     const goldenItems = ["a", "b", "c"];
     const goldenEnvelopes = [
@@ -62,21 +61,21 @@ describe("transforming WHATWG streams", () => {
     };
     describe("transformSerialize()", function () {
       it("should serialize to envelopes", async function () {
-        const stream = createReadableStream(goldenItems).pipeThrough(
-          transformSerialize(fakeSerialization),
-          {}
+        const it = transformAsyncIterable(
+          createAsyncIterable(goldenItems),
+          transformSerialize(fakeSerialization)
         );
-        const got = await readAll(stream);
+        const got = await readAll(it);
         expect(got).toEqual(goldenEnvelopes);
       });
     });
     describe("transformParse()", function () {
       it("should parse from envelopes", async function () {
-        const stream = createReadableStream(goldenEnvelopes).pipeThrough(
-          transformParse(fakeSerialization),
-          {}
+        const it = transformAsyncIterable(
+          createAsyncIterable(goldenEnvelopes),
+          transformParse(fakeSerialization)
         );
-        const got = await readAll(stream);
+        const got = await readAll(it);
         expect(got).toEqual(goldenItems);
       });
     });
@@ -122,38 +121,52 @@ describe("transforming WHATWG streams", () => {
 
     describe("transformSerialize()", function () {
       it("should serialize to envelopes", async function () {
-        const stream = createReadableStream(goldenItems).pipeThrough(
-          transformSerialize(serialization, endFlag, endSerialization),
-          {}
+        const it = transformAsyncIterable(
+          createAsyncIterable(goldenItems),
+          transformSerialize(serialization, endFlag, endSerialization)
         );
-        const got = await readAll(stream);
+        const got = await readAll(it);
         expect(got).toEqual(goldenEnvelopes);
       });
     });
 
     describe("transformParse()", function () {
       it("should parse from envelopes", async function () {
-        const stream = createReadableStream(goldenEnvelopes).pipeThrough(
-          transformParse(serialization, endFlag, endSerialization),
-          {}
+        const it = transformAsyncIterable(
+          createAsyncIterable(goldenEnvelopes),
+          transformParse(serialization, endFlag, endSerialization)
         );
-        const got = await readAll(stream);
+        const got = await readAll(it);
         expect(got).toEqual(goldenItems);
       });
-      it("should raise error on unexpected end flag", async function () {
-        const stream = createReadableStream(goldenEnvelopes).pipeThrough(
-          transformParse(serialization, endFlag, null),
-          {}
-        );
-        try {
-          await readAll(stream);
-          fail("expected error");
-        } catch (e) {
-          expect(e).toBeInstanceOf(ConnectError);
-          expect(connectErrorFromReason(e).message).toBe(
-            "[invalid_argument] unexpected end flag"
+      describe("with endCompression null", function () {
+        it("should raise error on unexpected end flag", async function () {
+          const it = transformAsyncIterable(
+            createAsyncIterable(goldenEnvelopes),
+            transformParse(serialization, endFlag, null)
           );
-        }
+          try {
+            await readAll(it);
+            fail("expected error");
+          } catch (e) {
+            expect(e).toBeInstanceOf(ConnectError);
+            expect(connectErrorFromReason(e).message).toBe(
+              "[invalid_argument] unexpected end flag"
+            );
+          }
+        });
+        it("should still parse to T", async function () {
+          const envelopesWithoutEndFlag = goldenEnvelopes.slice(0, 2);
+          const itemsWithoutEndFlag = goldenItems
+            .slice(0, 2)
+            .map((item) => item.value);
+          const it = transformAsyncIterable(
+            createAsyncIterable(envelopesWithoutEndFlag),
+            transformParse(serialization, endFlag, null)
+          );
+          const got = await readAll(it);
+          expect(got).toEqual(itemsWithoutEndFlag);
+        });
       });
     });
   });
@@ -180,20 +193,20 @@ describe("transforming WHATWG streams", () => {
 
     describe("transformJoin()", function () {
       it("should join envelopes", async function () {
-        const stream = createReadableStream(goldenEnvelopes).pipeThrough(
-          transformJoin(Number.MAX_SAFE_INTEGER),
-          {}
+        const it = transformAsyncIterable(
+          createAsyncIterable(goldenEnvelopes),
+          transformJoin(Number.MAX_SAFE_INTEGER)
         );
-        const gotBytes = await readAllBytes(stream);
+        const gotBytes = await readAllBytes(it);
         expect(gotBytes).toEqual(goldenBytes);
       });
       it("should honor writeMaxBytes", async function () {
-        const stream = createReadableStream(goldenEnvelopes).pipeThrough(
-          transformJoin(3),
-          {}
+        const it = transformAsyncIterable(
+          createAsyncIterable(goldenEnvelopes),
+          transformJoin(3)
         );
         try {
-          await readAll(stream);
+          await readAll(it);
           fail("expected error");
         } catch (e) {
           expect(e).toBeInstanceOf(ConnectError);
@@ -206,20 +219,20 @@ describe("transforming WHATWG streams", () => {
 
     describe("transformSplit()", function () {
       it("should split envelopes", async function () {
-        const stream = createReadableByteStream(goldenBytes).pipeThrough(
-          transformSplit(Number.MAX_SAFE_INTEGER),
-          {}
+        const it = transformAsyncIterable(
+          createAsyncIterableBytes(goldenBytes),
+          transformSplit(Number.MAX_SAFE_INTEGER)
         );
-        const got = await readAll(stream);
+        const got = await readAll(it);
         expect(got).toEqual(goldenEnvelopes);
       });
       it("should honor readMaxBytes", async function () {
-        const stream = createReadableByteStream(goldenBytes).pipeThrough(
-          transformSplit(3),
-          {}
+        const it = transformAsyncIterable(
+          createAsyncIterableBytes(goldenBytes),
+          transformSplit(3)
         );
         try {
-          await readAll(stream);
+          await readAll(it);
           fail("expected error");
         } catch (e) {
           expect(e).toBeInstanceOf(ConnectError);
@@ -284,20 +297,20 @@ describe("transforming WHATWG streams", () => {
 
     describe("transformCompress()", function () {
       it("should compress envelopes", async function () {
-        const stream = createReadableStream(uncompressedEnvelopes).pipeThrough(
-          transformCompress(compressionReverse, Number.MAX_SAFE_INTEGER, 0),
-          {}
+        const it = transformAsyncIterable(
+          createAsyncIterable(uncompressedEnvelopes),
+          transformCompress(compressionReverse, Number.MAX_SAFE_INTEGER, 0)
         );
-        const gotEnvelopes = await readAll(stream);
+        const gotEnvelopes = await readAll(it);
         expect(gotEnvelopes).toEqual(compressedEnvelopes);
       });
       it("should throw on compressed input", async function () {
-        const stream = createReadableStream(compressedEnvelopes).pipeThrough(
-          transformCompress(compressionReverse, 3, 0),
-          {}
+        const it = transformAsyncIterable(
+          createAsyncIterable(compressedEnvelopes),
+          transformCompress(compressionReverse, 3, 0)
         );
         try {
-          await readAll(stream);
+          await readAll(it);
           fail("expected error");
         } catch (e) {
           expect(e).toBeInstanceOf(ConnectError);
@@ -307,11 +320,11 @@ describe("transforming WHATWG streams", () => {
         }
       });
       it("should honor compressMinBytes", async function () {
-        const stream = createReadableStream(uncompressedEnvelopes).pipeThrough(
-          transformCompress(compressionReverse, Number.MAX_SAFE_INTEGER, 5),
-          {}
+        const it = transformAsyncIterable(
+          createAsyncIterable(uncompressedEnvelopes),
+          transformCompress(compressionReverse, Number.MAX_SAFE_INTEGER, 5)
         );
-        const gotEnvelopes = await readAll(stream);
+        const gotEnvelopes = await readAll(it);
         expect(gotEnvelopes).toEqual(uncompressedEnvelopes);
       });
       it("should honor writeMaxBytes for the compressed message", async function () {
@@ -326,12 +339,12 @@ describe("transforming WHATWG streams", () => {
             throw "unimplemented";
           },
         };
-        const stream = createReadableStream(uncompressedEnvelopes).pipeThrough(
-          transformCompress(compressionTo5Bytes, 4, 0),
-          {}
+        const it = transformAsyncIterable(
+          createAsyncIterable(uncompressedEnvelopes),
+          transformCompress(compressionTo5Bytes, 4, 0)
         );
         try {
-          await readAll(stream);
+          await readAll(it);
           fail("expected error");
         } catch (e) {
           expect(e).toBeInstanceOf(ConnectError);
@@ -340,32 +353,72 @@ describe("transforming WHATWG streams", () => {
           );
         }
       });
+      describe("with null compression", function () {
+        it("should not compress", async function () {
+          const it = transformAsyncIterable(
+            createAsyncIterable(uncompressedEnvelopes),
+            transformCompress(null, Number.MAX_SAFE_INTEGER, 0)
+          );
+          const gotEnvelopes = await readAll(it);
+          expect(gotEnvelopes).toEqual(uncompressedEnvelopes);
+        });
+        it("should throw on compressed input", async function () {
+          const it = transformAsyncIterable(
+            createAsyncIterable(compressedEnvelopes),
+            transformCompress(compressionReverse, 3, 0)
+          );
+          try {
+            await readAll(it);
+            fail("expected error");
+          } catch (e) {
+            expect(e).toBeInstanceOf(ConnectError);
+            expect(connectErrorFromReason(e).message).toBe(
+              "[internal] invalid envelope, already compressed"
+            );
+          }
+        });
+        it("should honor writeMaxBytes", async function () {
+          const it = transformAsyncIterable(
+            createAsyncIterable(uncompressedEnvelopes),
+            transformCompress(null, 3, 0)
+          );
+          try {
+            await readAll(it);
+            fail("expected error");
+          } catch (e) {
+            expect(e).toBeInstanceOf(ConnectError);
+            expect(connectErrorFromReason(e).message).toBe(
+              "[resource_exhausted] message size 4 is larger than configured writeMaxBytes 3"
+            );
+          }
+        });
+      });
     });
 
     describe("transformDecompress()", function () {
       it("should decompress envelopes", async function () {
-        const stream = createReadableStream(compressedEnvelopes).pipeThrough(
-          transformDecompress(compressionReverse, Number.MAX_SAFE_INTEGER),
-          {}
+        const it = transformAsyncIterable(
+          createAsyncIterable(compressedEnvelopes),
+          transformDecompress(compressionReverse, Number.MAX_SAFE_INTEGER)
         );
-        const gotEnvelopes = await readAll(stream);
+        const gotEnvelopes = await readAll(it);
         expect(gotEnvelopes).toEqual(uncompressedEnvelopes);
       });
       it("should not decompress uncompressed envelopes", async function () {
-        const stream = createReadableStream(uncompressedEnvelopes).pipeThrough(
-          transformDecompress(compressionReverse, Number.MAX_SAFE_INTEGER),
-          {}
+        const it = transformAsyncIterable(
+          createAsyncIterable(uncompressedEnvelopes),
+          transformDecompress(compressionReverse, Number.MAX_SAFE_INTEGER)
         );
-        const gotEnvelopes = await readAll(stream);
+        const gotEnvelopes = await readAll(it);
         expect(gotEnvelopes).toEqual(uncompressedEnvelopes);
       });
       it("should pass readMaxBytes to compression", async function () {
-        const stream = createReadableStream(compressedEnvelopes).pipeThrough(
-          transformDecompress(compressionReverse, 3),
-          {}
+        const it = transformAsyncIterable(
+          createAsyncIterable(compressedEnvelopes),
+          transformDecompress(compressionReverse, 3)
         );
         try {
-          await readAll(stream);
+          await readAll(it);
           fail("expected error");
         } catch (e) {
           expect(e).toBeInstanceOf(ConnectError);
@@ -374,6 +427,96 @@ describe("transforming WHATWG streams", () => {
           );
         }
       });
+      describe("with null compression", function () {
+        it("should not decompress uncompressed envelopes", async function () {
+          const it = transformAsyncIterable(
+            createAsyncIterable(uncompressedEnvelopes),
+            transformDecompress(null, Number.MAX_SAFE_INTEGER)
+          );
+          const gotEnvelopes = await readAll(it);
+          expect(gotEnvelopes).toEqual(uncompressedEnvelopes);
+        });
+        it("should raise error on compressed envelope", async function () {
+          const it = transformAsyncIterable(
+            createAsyncIterable(compressedEnvelopes),
+            transformDecompress(null, Number.MAX_SAFE_INTEGER)
+          );
+          try {
+            await readAll(it);
+            fail("expected error");
+          } catch (e) {
+            expect(e).toBeInstanceOf(ConnectError);
+            expect(connectErrorFromReason(e).message).toBe(
+              "[invalid_argument] received compressed envelope, but do not now how to decompress"
+            );
+          }
+        });
+      });
+    });
+  });
+
+  describe("error handling", function () {
+    const goldenItems = ["a", "b", "c"];
+    const serialization: Serialization<string> = {
+      serialize(data: string): Uint8Array {
+        if (data === "c") {
+          throw new Error("cannot serialize 'c'");
+        }
+        return new TextEncoder().encode(data);
+      },
+      parse(data: Uint8Array): string {
+        return new TextDecoder().decode(data);
+      },
+    };
+
+    it("should raise error when unhandled", async function () {
+      const it = transformAsyncIterable(
+        createAsyncIterable(goldenItems),
+        transformSerialize(serialization)
+      );
+      try {
+        await readAll(it);
+        fail("expected error");
+      } catch (e) {
+        expect(e).toBeInstanceOf(ConnectError);
+        if (e instanceof ConnectError) {
+          expect(e.code).toBe(Code.Internal);
+          expect(e.rawMessage).toBe("failed to serialize message");
+          expect(e.cause).toBeInstanceOf(Error);
+          if (e.cause instanceof Error) {
+            expect(e.cause.message).toBe("cannot serialize 'c'");
+          }
+        }
+      }
+    });
+
+    it("should catch error", async function () {
+      const goldenEnvelopes = [
+        {
+          data: new TextEncoder().encode("a"),
+          flags: 0b00000000,
+        },
+        {
+          data: new TextEncoder().encode("b"),
+          flags: 0b00000000,
+        },
+        {
+          data: new TextEncoder().encode("ERROR"),
+          flags: 0b00000000,
+        },
+      ];
+      const it = transformAsyncIterable(
+        createAsyncIterable(goldenItems),
+        transformSerialize(serialization),
+        transformCatch<EnvelopedMessage>(() => {
+          return {
+            flags: 0,
+            data: new TextEncoder().encode("ERROR"),
+          };
+        })
+      );
+      const result = await readAll(it);
+      expect(result).toEqual(goldenEnvelopes);
     });
   });
 
@@ -400,7 +543,7 @@ describe("transforming WHATWG streams", () => {
         return new TextDecoder().decode(data).slice(0, -1);
       },
     };
-    const compressionRevers: Compression = {
+    const compressionReverse: Compression = {
       name: "fake",
       compress(bytes) {
         const b = new Uint8Array(bytes.byteLength);
@@ -423,26 +566,16 @@ describe("transforming WHATWG streams", () => {
     };
 
     it("should serialize, compress, join, split, decompress, and parse", async function () {
-      const stream = createReadableStream(goldenItemsWithEnd)
-        .pipeThrough(
-          transformSerialize(serialization, endFlag, endSerialization),
-          {}
-        )
-        .pipeThrough(
-          transformCompress(compressionRevers, Number.MAX_SAFE_INTEGER, 0),
-          {}
-        )
-        .pipeThrough(transformJoin(Number.MAX_SAFE_INTEGER), {})
-        .pipeThrough(transformSplit(Number.MAX_SAFE_INTEGER), {})
-        .pipeThrough(
-          transformDecompress(compressionRevers, Number.MAX_SAFE_INTEGER),
-          {}
-        )
-        .pipeThrough(
-          transformParse(serialization, endFlag, endSerialization),
-          {}
-        );
-      const result = await readAll(stream);
+      const it = transformAsyncIterable(
+        createAsyncIterable(goldenItemsWithEnd),
+        transformSerialize(serialization, endFlag, endSerialization),
+        transformCompress(compressionReverse, Number.MAX_SAFE_INTEGER, 0),
+        transformJoin(Number.MAX_SAFE_INTEGER),
+        transformSplit(Number.MAX_SAFE_INTEGER),
+        transformDecompress(compressionReverse, Number.MAX_SAFE_INTEGER),
+        transformParse(serialization, endFlag, endSerialization)
+      );
+      const result = await readAll(it);
       expect(result).toEqual(goldenItemsWithEnd);
     });
   });

--- a/packages/connect-core/src/transform-iterable.ts
+++ b/packages/connect-core/src/transform-iterable.ts
@@ -1,0 +1,607 @@
+// Copyright 2021-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Code } from "./code.js";
+import { ConnectError } from "./connect-error.js";
+import type { EnvelopedMessage, ParsedEnvelopedMessage } from "./envelope.js";
+import type { Serialization } from "./serialization.js";
+import { compressedFlag, Compression } from "./compression.js";
+
+/**
+ * A function that takes an asynchronous iterable as an input, and returns a
+ * transformed asynchronous iterable.
+ *
+ * The following function is a simple implementation that yields the input:
+ *
+ * ```ts
+ * async function* t<T>(input) {
+ *   yield* input;
+ * }
+ * ```
+ *
+ * The following function takes fetch responses as an input, and yields the
+ * text body of each:
+ *
+ * ```ts
+ * async function* t<T>(input: AsyncIterable<Response>): AsyncIterable<string> {
+ *   for await (const r of input) {
+ *     yield await r.text();
+ *   }
+ * }
+ * ```
+ *
+ * The function may accept an AbortSignal.
+ */
+export type AsyncIterableTransformer<I, O = I> = (
+  data: AsyncIterable<I>,
+  options?: TransformOptions
+) => AsyncIterable<O>;
+
+interface TransformOptions {
+  signal?: AbortSignal;
+}
+
+/**
+ * Apply one or more transformations to an asynchronous iterable.
+ */
+export function transformAsyncIterable<T1, T2>(
+  iterable: AsyncIterable<T1>,
+  transform: AsyncIterableTransformer<T1, T2>,
+  options?: TransformOptions
+): AsyncIterable<T2>;
+/**
+ * Apply one or more transformations to an asynchronous iterable.
+ */
+export function transformAsyncIterable<T1, T2, T3>(
+  iterable: AsyncIterable<T1>,
+  transform1: AsyncIterableTransformer<T1, T2>,
+  transform2: AsyncIterableTransformer<T2, T3>,
+  options?: TransformOptions
+): AsyncIterable<T3>;
+/**
+ * Apply one or more transformations to an asynchronous iterable.
+ */
+export function transformAsyncIterable<T1, T2, T3, T4>(
+  iterable: AsyncIterable<T1>,
+  transform1: AsyncIterableTransformer<T1, T2>,
+  transform2: AsyncIterableTransformer<T2, T3>,
+  transform3: AsyncIterableTransformer<T3, T4>,
+  options?: TransformOptions
+): AsyncIterable<T4>;
+/**
+ * Apply one or more transformations to an asynchronous iterable.
+ */
+export function transformAsyncIterable<T1, T2, T3, T4, T5>(
+  iterable: AsyncIterable<T1>,
+  transform1: AsyncIterableTransformer<T1, T2>,
+  transform2: AsyncIterableTransformer<T2, T3>,
+  transform3: AsyncIterableTransformer<T3, T4>,
+  transform4: AsyncIterableTransformer<T4, T5>,
+  options?: TransformOptions
+): AsyncIterable<T5>;
+/**
+ * Apply one or more transformations to an asynchronous iterable.
+ */
+export function transformAsyncIterable<T1, T2, T3, T4, T5, T6>(
+  iterable: AsyncIterable<T1>,
+  transform1: AsyncIterableTransformer<T1, T2>,
+  transform2: AsyncIterableTransformer<T2, T3>,
+  transform3: AsyncIterableTransformer<T3, T4>,
+  transform4: AsyncIterableTransformer<T4, T5>,
+  transform5: AsyncIterableTransformer<T5, T6>,
+  options?: TransformOptions
+): AsyncIterable<T6>;
+/**
+ * Apply one or more transformations to an asynchronous iterable.
+ */
+export function transformAsyncIterable<T1, T2, T3, T4, T5, T6, T7>(
+  iterable: AsyncIterable<T1>,
+  transform1: AsyncIterableTransformer<T1, T2>,
+  transform2: AsyncIterableTransformer<T2, T3>,
+  transform3: AsyncIterableTransformer<T3, T4>,
+  transform4: AsyncIterableTransformer<T4, T5>,
+  transform5: AsyncIterableTransformer<T5, T6>,
+  transform6: AsyncIterableTransformer<T6, T7>,
+  options?: TransformOptions
+): AsyncIterable<T7>;
+/**
+ * Apply one or more transformations to an asynchronous iterable.
+ */
+export function transformAsyncIterable<T1, T2, T3, T4, T5, T6, T7, T8>(
+  iterable: AsyncIterable<T1>,
+  transform1: AsyncIterableTransformer<T1, T2>,
+  transform2: AsyncIterableTransformer<T2, T3>,
+  transform3: AsyncIterableTransformer<T3, T4>,
+  transform4: AsyncIterableTransformer<T4, T5>,
+  transform5: AsyncIterableTransformer<T5, T6>,
+  transform6: AsyncIterableTransformer<T6, T7>,
+  transform7: AsyncIterableTransformer<T7, T8>,
+  options?: TransformOptions
+): AsyncIterable<T8>;
+/**
+ * Apply one or more transformations to an asynchronous iterable.
+ */
+export function transformAsyncIterable<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+  iterable: AsyncIterable<T1>,
+  transform1: AsyncIterableTransformer<T1, T2>,
+  transform2: AsyncIterableTransformer<T2, T3>,
+  transform3: AsyncIterableTransformer<T3, T4>,
+  transform4: AsyncIterableTransformer<T4, T5>,
+  transform5: AsyncIterableTransformer<T5, T6>,
+  transform6: AsyncIterableTransformer<T6, T7>,
+  transform7: AsyncIterableTransformer<T7, T8>,
+  transform8: AsyncIterableTransformer<T8, T9>,
+  options?: TransformOptions
+): AsyncIterable<T9>;
+/**
+ * Apply one or more transformations to an asynchronous iterable.
+ */
+export function transformAsyncIterable<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
+  iterable: AsyncIterable<T1>,
+  transform1: AsyncIterableTransformer<T1, T2>,
+  transform2: AsyncIterableTransformer<T2, T3>,
+  transform3: AsyncIterableTransformer<T3, T4>,
+  transform4: AsyncIterableTransformer<T4, T5>,
+  transform5: AsyncIterableTransformer<T5, T6>,
+  transform6: AsyncIterableTransformer<T6, T7>,
+  transform7: AsyncIterableTransformer<T7, T8>,
+  transform8: AsyncIterableTransformer<T8, T9>,
+  transform9: AsyncIterableTransformer<T9, T10>,
+  options?: TransformOptions
+): AsyncIterable<T10>;
+// prettier-ignore
+/**
+ * Apply one or more transformations to an asynchronous iterable.
+ */
+export function transformAsyncIterable<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
+  iterable: AsyncIterable<T1>,
+  transform1: AsyncIterableTransformer<T1, T2>,
+  transform2: AsyncIterableTransformer<T2, T3>,
+  transform3: AsyncIterableTransformer<T3, T4>,
+  transform4: AsyncIterableTransformer<T4, T5>,
+  transform5: AsyncIterableTransformer<T5, T6>,
+  transform6: AsyncIterableTransformer<T6, T7>,
+  transform7: AsyncIterableTransformer<T7, T8>,
+  transform8: AsyncIterableTransformer<T8, T9>,
+  transform9: AsyncIterableTransformer<T9, T10>,
+  transform10: AsyncIterableTransformer<T10, T11>,
+  options?: TransformOptions
+): AsyncIterable<T11>;
+// prettier-ignore
+/**
+ * Apply one or more transformations to an asynchronous iterable.
+ */
+export function transformAsyncIterable<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(
+  iterable: AsyncIterable<T1>,
+  transform1: AsyncIterableTransformer<T1, T2>,
+  transform2: AsyncIterableTransformer<T2, T3>,
+  transform3: AsyncIterableTransformer<T3, T4>,
+  transform4: AsyncIterableTransformer<T4, T5>,
+  transform5: AsyncIterableTransformer<T5, T6>,
+  transform6: AsyncIterableTransformer<T6, T7>,
+  transform7: AsyncIterableTransformer<T7, T8>,
+  transform8: AsyncIterableTransformer<T8, T9>,
+  transform9: AsyncIterableTransformer<T9, T10>,
+  transform10: AsyncIterableTransformer<T10, T11>,
+  transform11: AsyncIterableTransformer<T11, T12>,
+  options?: TransformOptions
+): AsyncIterable<T12>;
+export async function* transformAsyncIterable<I, O>(
+  iterable: AsyncIterable<I>,
+  ...rest: (AsyncIterableTransformer<unknown> | TransformOptions | undefined)[]
+): AsyncIterable<O> {
+  let it: AsyncIterable<unknown> = iterable;
+  const [transforms, opt] = pickTransforms(rest);
+  for (const t of transforms) {
+    it = t(it, opt);
+  }
+  opt?.signal?.throwIfAborted();
+  for await (const item of it) {
+    opt?.signal?.throwIfAborted();
+    yield item as O;
+  }
+}
+
+function pickTransforms(
+  rest: (AsyncIterableTransformer<unknown> | TransformOptions | undefined)[]
+): [AsyncIterableTransformer<unknown>[], TransformOptions | undefined] {
+  let opt: TransformOptions | undefined;
+  if (typeof rest[rest.length - 1] != "function") {
+    opt = rest.pop() as TransformOptions;
+  }
+  return [rest as AsyncIterableTransformer<unknown>[], opt];
+}
+
+type TransformCatchErrorFn<C> =
+  | ((reason: unknown) => C)
+  | ((reason: unknown) => Promise<C>);
+
+/**
+ * Creates an IterableTransform that catches any error in the source, and
+ * replaces it with the value returned from the given catchError function.
+ *
+ * Once an error is caught, the value returned from catchError is the last
+ * value in the transformed iterable.
+ */
+export function transformCatch<T, C = T>(
+  catchError: TransformCatchErrorFn<C>
+): AsyncIterableTransformer<T, T | C> {
+  return async function* (iterable) {
+    try {
+      for await (const chunk of iterable) {
+        yield chunk;
+      }
+    } catch (e) {
+      yield await catchError(e);
+    }
+  };
+}
+
+/**
+ * Creates an IterableTransform that takes a specified type as input,
+ * and serializes it as an enveloped messages.
+ *
+ * Note that this function has an override that lets the input stream
+ * distinguish between regular messages, and end-of-stream messages, as used
+ * by the RPP-web and Connect protocols.
+ */
+export function transformSerialize<T>(
+  serialization: Serialization<T>
+): AsyncIterableTransformer<T, EnvelopedMessage>;
+/**
+ * Creates an IterableTransform that takes a value or special end type, and
+ * serializes it as an enveloped message.
+ *
+ * For example, an input with { end: true, value: ... } is serialized using
+ * the given endSerialization, and the resulting enveloped message has the
+ * given endStreamFlag.
+ *
+ * An input with { end: false, value: ... } is serialized using the given
+ * serialization, and the resulting enveloped message does not have the given
+ * endStreamFlag.
+ */
+export function transformSerialize<T, E>(
+  serialization: Serialization<T>,
+  endStreamFlag: number,
+  endSerialization: Serialization<E>
+): AsyncIterableTransformer<ParsedEnvelopedMessage<T, E>, EnvelopedMessage>;
+export function transformSerialize<T, E>(
+  serialization: Serialization<T>,
+  endStreamFlag?: number,
+  endSerialization?: Serialization<E>
+):
+  | AsyncIterableTransformer<T, EnvelopedMessage>
+  | AsyncIterableTransformer<ParsedEnvelopedMessage<T, E>, EnvelopedMessage> {
+  if (endStreamFlag === undefined || endSerialization === undefined) {
+    return async function* (iterable: AsyncIterable<T>) {
+      for await (const chunk of iterable) {
+        let data: Uint8Array;
+        try {
+          data = serialization.serialize(chunk);
+        } catch (e) {
+          throw new ConnectError(
+            "failed to serialize message",
+            Code.Internal,
+            undefined,
+            undefined,
+            e
+          );
+        }
+        yield { flags: 0, data };
+      }
+    };
+  }
+  return async function* (
+    iterable: AsyncIterable<ParsedEnvelopedMessage<T, E>>
+  ) {
+    for await (const chunk of iterable) {
+      let data: Uint8Array;
+      let flags = 0;
+      if (chunk.end) {
+        flags = flags | endStreamFlag;
+        try {
+          data = endSerialization.serialize(chunk.value);
+        } catch (e) {
+          throw new ConnectError(
+            "failed to serialize end",
+            Code.Internal,
+            undefined,
+            undefined,
+            e
+          );
+        }
+      } else {
+        try {
+          data = serialization.serialize(chunk.value);
+        } catch (e) {
+          throw new ConnectError(
+            "failed to serialize message",
+            Code.Internal,
+            undefined,
+            undefined,
+            e
+          );
+        }
+      }
+      yield { flags, data };
+    }
+  };
+}
+
+/**
+ * Creates an IterableTransform that takes enveloped messages as input,
+ * parses the envelope payload and outputs the result.
+ *
+ * Note that this function has overrides that let the stream distinguish
+ * between regular messages, and end-of-stream messages, as used by the
+ * gRPP-web and Connect protocols.
+ */
+export function transformParse<T>(
+  serialization: Serialization<T>
+): AsyncIterableTransformer<EnvelopedMessage, T>;
+/**
+ * Creates an IterableTransform that takes enveloped messages as input,
+ * parses the envelope payload and outputs the result.
+ *
+ * Note that this override will look for the given endStreamFlag, and raise
+ * and error if it is set.
+ */
+export function transformParse<T>(
+  serialization: Serialization<T>,
+  endStreamFlag: number,
+  endSerialization: null
+): AsyncIterableTransformer<EnvelopedMessage, T>;
+/**
+ * Creates an IterableTransform that takes an enveloped message as input,
+ * and outputs a ParsedEnvelopedMessage.
+ *
+ * For example, if the given endStreamFlag is set for an input envelope, its
+ * payload is parsed using the given endSerialization, and an object with
+ * { end: true, value: ... } is returned.
+ *
+ * If the endStreamFlag is not set, the payload is parsed using the given
+ * serialization, and an object with { end: false, value: ... } is returned.
+ */
+export function transformParse<T, E>(
+  serialization: Serialization<T>,
+  endStreamFlag: number,
+  endSerialization: Serialization<E>
+): AsyncIterableTransformer<EnvelopedMessage, ParsedEnvelopedMessage<T, E>>;
+export function transformParse<T, E>(
+  serialization: Serialization<T>,
+  endStreamFlag?: number,
+  endSerialization?: null | Serialization<E>
+):
+  | AsyncIterableTransformer<EnvelopedMessage, T>
+  | AsyncIterableTransformer<EnvelopedMessage, ParsedEnvelopedMessage<T, E>> {
+  // code path always yields ParsedEnvelopedMessage<T, E>
+  if (endSerialization && endStreamFlag !== undefined) {
+    return async function* (
+      iterable: AsyncIterable<EnvelopedMessage>
+    ): AsyncIterable<ParsedEnvelopedMessage<T, E>> {
+      for await (const { flags, data } of iterable) {
+        if ((flags & endStreamFlag) === endStreamFlag) {
+          let value: E;
+          try {
+            value = endSerialization.parse(data);
+          } catch (e) {
+            throw new ConnectError(
+              "failed to parse end",
+              Code.InvalidArgument,
+              undefined,
+              undefined,
+              e
+            );
+          }
+          yield { value, end: true };
+        } else {
+          let value: T;
+          try {
+            value = serialization.parse(data);
+          } catch (e) {
+            throw new ConnectError(
+              "failed to serialize message",
+              Code.Internal,
+              undefined,
+              undefined,
+              e
+            );
+          }
+          yield { value, end: false };
+        }
+      }
+    };
+  }
+  // code path always yields T
+  return async function* (
+    iterable: AsyncIterable<EnvelopedMessage>
+  ): AsyncIterable<T> {
+    for await (const { flags, data } of iterable) {
+      if (
+        endStreamFlag !== undefined &&
+        (flags & endStreamFlag) === endStreamFlag
+      ) {
+        throw new ConnectError("unexpected end flag", Code.InvalidArgument);
+      }
+      let value: T;
+      try {
+        value = serialization.parse(data);
+      } catch (e) {
+        throw new ConnectError(
+          "failed to serialize message",
+          Code.Internal,
+          undefined,
+          undefined,
+          e
+        );
+      }
+      yield value;
+    }
+  };
+}
+
+/**
+ * Creates an IterableTransform that takes enveloped messages as input, and
+ * compresses them if they are larger than compressMinBytes.
+ *
+ * An error is raised if an enveloped message is already compressed, or if
+ * the compressed payload is larger than writeMaxBytes.
+ *
+ * If compression is null, an error is raised if the uncompressed payload is
+ * larger than writeMaxBytes.
+ */
+export function transformCompress(
+  compression: Compression | null,
+  writeMaxBytes: number,
+  compressMinBytes: number
+): AsyncIterableTransformer<EnvelopedMessage, EnvelopedMessage> {
+  return async function* (iterable) {
+    for await (let { flags, data } of iterable) {
+      if ((flags & compressedFlag) === compressedFlag) {
+        throw new ConnectError(
+          "invalid envelope, already compressed",
+          Code.Internal
+        );
+      }
+      if (compression && data.byteLength >= compressMinBytes) {
+        data = await compression.compress(data);
+        flags = flags | compressedFlag;
+      }
+      if (data.byteLength > writeMaxBytes) {
+        throw new ConnectError(
+          `message size ${data.byteLength} is larger than configured writeMaxBytes ${writeMaxBytes}`,
+          Code.ResourceExhausted
+        );
+      }
+      yield { data, flags };
+    }
+  };
+}
+
+/**
+ * Creates an IterableTransform that takes enveloped messages as input, and
+ * decompresses them using the given compression.
+ *
+ * Raises an error if an envelope is compressed, but compression is null.
+ */
+export function transformDecompress(
+  compression: Compression | null,
+  readMaxBytes: number
+): AsyncIterableTransformer<EnvelopedMessage, EnvelopedMessage> {
+  return async function* (iterable) {
+    for await (let { flags, data } of iterable) {
+      if ((flags & compressedFlag) !== compressedFlag) {
+        yield { flags, data };
+        continue;
+      }
+      if (!compression) {
+        throw new ConnectError(
+          "received compressed envelope, but do not now how to decompress",
+          Code.InvalidArgument
+        );
+      }
+      data = await compression.decompress(data, readMaxBytes);
+      flags = flags ^ compressedFlag;
+      yield { data, flags };
+    }
+  };
+}
+
+/**
+ * Create an IterableTransform that takes enveloped messages as input and
+ * joins them into a stream of raw bytes.
+ *
+ * The TransformStream raises an error if the payload of an enveloped message
+ * is larger than writeMaxBytes.
+ */
+export function transformJoin(
+  writeMaxBytes: number
+): AsyncIterableTransformer<EnvelopedMessage, Uint8Array> {
+  return async function* (iterable) {
+    for await (const { flags, data } of iterable) {
+      if (data.byteLength > writeMaxBytes) {
+        throw new ConnectError(
+          `message size ${data.byteLength} is larger than configured writeMaxBytes ${writeMaxBytes}`,
+          Code.ResourceExhausted
+        );
+      }
+      const bytes = new Uint8Array(data.byteLength + 5);
+      bytes.set(data, 5);
+      const v = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+      v.setUint8(0, flags); // first byte is flags
+      v.setUint32(1, data.byteLength); // 4 bytes message length
+      yield bytes;
+    }
+  };
+}
+
+/**
+ * Create an IterableTransform that takes raw bytes as input and splits them
+ * into enveloped messages.
+ *
+ * The TransformStream raises an error
+ * - if the payload of an enveloped message is larger than readMaxBytes,
+ * - if the stream ended before an enveloped message fully arrived,
+ * - or if the stream ended with extraneous data.
+ */
+export function transformSplit(
+  readMaxBytes: number
+): AsyncIterableTransformer<Uint8Array, EnvelopedMessage> {
+  return async function* (iterable) {
+    let buffer = new Uint8Array(0);
+    let header: { length: number; flags: number } | undefined = undefined;
+    for await (const chunk of iterable) {
+      const g = new Uint8Array(buffer.byteLength + chunk.byteLength);
+      g.set(buffer);
+      g.set(chunk, buffer.byteLength);
+      buffer = g;
+      if (buffer.byteLength < 5) {
+        continue;
+      }
+      if (header === undefined) {
+        const v = new DataView(buffer.buffer, buffer.byteOffset, 5);
+        const flags = v.getUint8(0); // first byte is flags
+        const length = v.getUint32(1); // 4 bytes message length
+        if (length > readMaxBytes) {
+          throw new ConnectError(
+            `message size ${length} is larger than configured readMaxBytes ${readMaxBytes}`,
+            Code.ResourceExhausted
+          );
+        }
+        header = { length, flags };
+      }
+      if (buffer.byteLength - 5 < header.length) {
+        continue;
+      }
+      const data = buffer.subarray(5, 5 + header.length);
+      buffer = buffer.subarray(5 + header.length);
+      yield { flags: header.flags, data };
+      header = undefined;
+    }
+    if (header) {
+      throw new ConnectError(
+        `protocol error: promised ${header.length} bytes in envelope, got ${
+          buffer.byteLength - 5
+        }`,
+        Code.InvalidArgument
+      );
+    }
+    if (buffer.byteLength) {
+      throw new ConnectError(
+        `protocol error: received ${buffer.byteLength} extra bytes`,
+        Code.DataLoss
+      );
+    }
+  };
+}

--- a/packages/connect-core/src/transform-iterable.ts
+++ b/packages/connect-core/src/transform-iterable.ts
@@ -507,7 +507,7 @@ export function transformDecompress(
       }
       if (!compression) {
         throw new ConnectError(
-          "received compressed envelope, but do not now how to decompress",
+          "received compressed envelope, but do not know how to decompress",
           Code.InvalidArgument
         );
       }

--- a/packages/connect-web-bench/README.md
+++ b/packages/connect-web-bench/README.md
@@ -10,6 +10,6 @@ it like a web server would usually do.
 
 | code generator | bundle size        | minified               | compressed           |
 |----------------|-------------------:|-----------------------:|---------------------:|
-| connect-web    | 102,761 b | 43,942 b | 12,070 b |
+| connect-web    | 102,761 b | 43,942 b | 12,063 b |
 | connect-web (legacy) | 94,850 b | 40,976 b | 11,358 b |
 | grpc-web       | 414,222 b    | 301,127 b    | 53,226 b |


### PR DESCRIPTION
This introduces asynchronous iterables as a simple alternative to WHATWG transform streams.

For context: Our spike with the WHATWG transform streams added in https://github.com/bufbuild/connect-web/pull/408 showed a couple of problems:
- `stream.Readable.toWeb` was only added in Node 17
- `http.ServerResponse` is not actually an instance of `stream.Writable` and cannot easily be used with `streamWritable.toWeb`
- Errors in a pipeline of transformations cannot easily be intercepted

While asynchronous iterables means still require us to bridge to Node requests / responses, this leaves us with just one code path, that also happens to be more flexible and does not require any polyfills at all. A spike with a gRPC-web handler has passed first tests.