### PR TITLE
Add compressionNegotiate() to @bufbuild/connect-core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1088,6 +1088,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
       "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dev": true,
       "dependencies": {
         "streamsearch": "^1.1.0"
       },
@@ -3329,6 +3330,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
       "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "dev": true,
       "engines": {
         "node": ">=10.0.0"
       }
@@ -3548,6 +3550,7 @@
       "version": "5.14.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-5.14.0.tgz",
       "integrity": "sha512-yJlHYw6yXPPsuOH0x2Ib1Km61vu4hLiRRQoafs+WUgX1vO64vgnxiCEN9dpIrhZyHFsai3F0AEj4P9zy19enEQ==",
+      "dev": true,
       "dependencies": {
         "busboy": "^1.6.0"
       },
@@ -3724,13 +3727,11 @@
       "name": "@bufbuild/connect-core",
       "version": "0.6.0",
       "license": "Apache-2.0",
-      "dependencies": {
-        "undici": "^5.13.0"
-      },
       "devDependencies": {
         "@bufbuild/protoc-gen-es": "^1.0.0",
         "@types/jasmine": "^4.3.0",
-        "jasmine": "^4.5.0"
+        "jasmine": "^4.5.0",
+        "undici": "^5.13.0"
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^1.0.0"
@@ -4593,6 +4594,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
       "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dev": true,
       "requires": {
         "streamsearch": "^1.1.0"
       }
@@ -6253,7 +6255,8 @@
     "streamsearch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "dev": true
     },
     "string-width": {
       "version": "4.2.3",
@@ -6398,6 +6401,7 @@
       "version": "5.14.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-5.14.0.tgz",
       "integrity": "sha512-yJlHYw6yXPPsuOH0x2Ib1Km61vu4hLiRRQoafs+WUgX1vO64vgnxiCEN9dpIrhZyHFsai3F0AEj4P9zy19enEQ==",
+      "dev": true,
       "requires": {
         "busboy": "^1.6.0"
       }

--- a/packages/connect-core/package.json
+++ b/packages/connect-core/package.json
@@ -57,9 +57,7 @@
   "devDependencies": {
     "@bufbuild/protoc-gen-es": "^1.0.0",
     "@types/jasmine": "^4.3.0",
-    "jasmine": "^4.5.0"
-  },
-  "dependencies": {
+    "jasmine": "^4.5.0",
     "undici": "^5.13.0"
   }
 }

--- a/packages/connect-core/src/compression.spec.ts
+++ b/packages/connect-core/src/compression.spec.ts
@@ -1,0 +1,111 @@
+// Copyright 2021-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Compression, compressionNegotiate } from "./compression.js";
+import { ConnectError } from "./connect-error.js";
+import { node16FetchHeadersPolyfill } from "./node16-polyfill-helper.spec.js";
+
+node16FetchHeadersPolyfill();
+
+describe("compressionNegotiate()", function () {
+  const compressionA: Compression = {
+    name: "a",
+    compress: (bytes) => Promise.resolve(bytes),
+    decompress: (bytes) => Promise.resolve(bytes),
+  };
+  const compressionB: Compression = {
+    ...compressionA,
+    name: "b",
+  };
+
+  describe("no encoding or accept-encoding specified", function () {
+    const r = compressionNegotiate(
+      [compressionA, compressionB],
+      null,
+      null,
+      "accept-encoding"
+    );
+    it("should return null for request and response compression", function () {
+      expect(r.error).toBeUndefined();
+      expect(r.request).toBeNull();
+      expect(r.response).toBeNull();
+    });
+  });
+
+  describe("accept-encoding specified, but no encoding set", function () {
+    const r = compressionNegotiate(
+      [compressionA, compressionB],
+      null,
+      "z,b,a,f",
+      "accept-encoding"
+    );
+    it("should return request compression null", function () {
+      expect(r.error).toBeUndefined();
+      expect(r.request).toBeNull();
+    });
+    it("should use first accepted compression for the response", function () {
+      expect(r.error).toBeUndefined();
+      expect(r.response).toBe(compressionB);
+    });
+  });
+
+  describe("encoding specified, but no accept-encoding", function () {
+    const r = compressionNegotiate(
+      [compressionA, compressionB],
+      "a",
+      null,
+      "accept-encoding"
+    );
+    it("should return request encoding", function () {
+      expect(r.error).toBeUndefined();
+      expect(r.request).toBe(compressionA);
+      expect(r.response).toBe(compressionA);
+    });
+  });
+
+  describe("no supported accept-encoding specified", function () {
+    const r = compressionNegotiate(
+      [compressionA, compressionB],
+      "a",
+      "x,y,z",
+      "accept-encoding"
+    );
+    it("should return response compression null", function () {
+      expect(r.error).toBeUndefined();
+      expect(r.request).toBe(compressionA);
+      expect(r.response).toBeNull();
+    });
+  });
+
+  describe("unsupported encoding set", function () {
+    const r = compressionNegotiate(
+      [compressionA, compressionB],
+      "z",
+      "a,b",
+      "accept-encoding"
+    );
+    it("should return error", function () {
+      expect(r.error).toBeInstanceOf(ConnectError);
+      if (r.error instanceof ConnectError) {
+        expect(r.error.message).toBe(
+          '[unimplemented] unknown compression "z": supported encodings are a,b'
+        );
+      }
+      expect(r.request).toBe(null);
+    });
+    it("should still use first accepted compression for the response", function () {
+      expect(r.response).toBe(compressionA);
+    });
+  });
+});

--- a/packages/connect-core/src/compression.ts
+++ b/packages/connect-core/src/compression.ts
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { ConnectError } from "./connect-error.js";
+import { Code } from "./code.js";
+
 /**
  * compressedFlag indicates that the data in a EnvelopedMessage is
  * compressed. It has the same meaning in the gRPC-Web, gRPC-HTTP2,
@@ -41,4 +44,60 @@ export interface Compression {
    * size exceeds readMaxBytes.
    */
   decompress: (bytes: Uint8Array, readMaxBytes: number) => Promise<Uint8Array>;
+}
+
+/**
+ * Validates the request encoding and determines the accepted response encoding.
+ *
+ * Returns the request and response compression to use. If the client requested
+ * an encoding that is not available, the returned object contains an error that
+ * must be used for the response.
+ */
+export function compressionNegotiate(
+  available: Compression[],
+  requested: string | null, // e.g. the value of the Grpc-Encoding header
+  accepted: string | null, // e.g. the value of the Grpc-Accept-Encoding header
+  headerNameAcceptEncoding: string // e.g. the name of the Grpc-Accept-Encoding header
+): {
+  request: Compression | null;
+  response: Compression | null;
+  error?: ConnectError;
+} {
+  let request = null;
+  let response = null;
+  let error = undefined;
+  if (requested !== null && requested !== "identity") {
+    const found = available.find((c) => c.name === requested);
+    if (found) {
+      request = found;
+    } else {
+      // To comply with https://github.com/grpc/grpc/blob/master/doc/compression.md
+      // and the Connect protocol, we return code "unimplemented" and specify
+      // acceptable compression(s).
+      const acceptable = available.map((c) => c.name).join(",");
+      error = new ConnectError(
+        `unknown compression "${requested}": supported encodings are ${acceptable}`,
+        Code.Unimplemented,
+        {
+          [headerNameAcceptEncoding]: acceptable,
+        }
+      );
+    }
+  }
+  if (accepted === null || accepted === "") {
+    // Support asymmetric compression. This logic follows
+    // https://github.com/grpc/grpc/blob/master/doc/compression.md and common
+    // sense.
+    response = request;
+  } else {
+    const acceptNames = accepted.split(",").map((n) => n.trim());
+    for (const name of acceptNames) {
+      const found = available.find((c) => c.name === name);
+      if (found) {
+        response = found;
+        break;
+      }
+    }
+  }
+  return { request, response, error };
 }

--- a/packages/connect-core/src/connect-error.spec.ts
+++ b/packages/connect-core/src/connect-error.spec.ts
@@ -20,18 +20,15 @@ import {
   ScalarType,
   Struct,
 } from "@bufbuild/protobuf";
-import { Headers as UndiciHeaders } from "undici";
 import {
   ConnectError,
   connectErrorDetails,
   connectErrorFromReason,
 } from "./connect-error.js";
 import { Code } from "./code.js";
+import { node16FetchHeadersPolyfill } from "./node16-polyfill-helper.spec.js";
 
-// TODO we need to replace all Headers ctor calls in our code or require Node.js >= v18
-if (typeof globalThis.Headers !== "function") {
-  globalThis.Headers = UndiciHeaders as unknown as typeof Headers;
-}
+node16FetchHeadersPolyfill();
 
 describe("ConnectError", () => {
   describe("constructor", () => {

--- a/packages/connect-core/src/http-headers.spec.ts
+++ b/packages/connect-core/src/http-headers.spec.ts
@@ -14,6 +14,9 @@
 
 import { proto3, ScalarType } from "@bufbuild/protobuf";
 import { decodeBinaryHeader, encodeBinaryHeader } from "./http-headers.js";
+import { node16FetchHeadersPolyfill } from "./node16-polyfill-helper.spec.js";
+
+node16FetchHeadersPolyfill();
 
 // prettier-ignore
 const M = proto3.makeMessageType("handwritten.M", [

--- a/packages/connect-core/src/index.ts
+++ b/packages/connect-core/src/index.ts
@@ -57,7 +57,11 @@ export {
   envelopeDecompress,
   envelopeCompress,
 } from "./envelope.js";
-export { Compression, compressedFlag } from "./compression.js";
+export {
+  Compression,
+  compressedFlag,
+  compressionNegotiate,
+} from "./compression.js";
 export {
   streamTransformCompress,
   streamTransformDecompress,

--- a/packages/connect-core/src/node16-polyfill-helper.spec.ts
+++ b/packages/connect-core/src/node16-polyfill-helper.spec.ts
@@ -1,0 +1,51 @@
+// Copyright 2021-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  ReadableStream as NodeReadableStream,
+  TransformStream as NodeTransformStream,
+  WritableStream as NodeWritableStream,
+} from "stream/web";
+import { Headers as UndiciHeaders } from "undici";
+
+/**
+ * Make the Headers implementation of the fetch API available in the global
+ * scope.
+ */
+export function node16FetchHeadersPolyfill() {
+  if (typeof globalThis.Headers !== "function") {
+    globalThis.Headers = UndiciHeaders as unknown as typeof Headers;
+  }
+}
+
+/**
+ * Make the WHATWG stream implementation of Node.js v16 available in the global
+ * scope.
+ */
+export function node16WhatwgStreamPolyfill() {
+  // node >= v16 has an implementation for WHATWG streams, but doesn't expose
+  // them in the global scope, nor globalThis.
+  if (typeof globalThis.ReadableStream !== "function") {
+    globalThis.ReadableStream =
+      NodeReadableStream as unknown as typeof ReadableStream;
+  }
+  if (typeof globalThis.WritableStream !== "function") {
+    globalThis.WritableStream =
+      NodeWritableStream as unknown as typeof WritableStream;
+  }
+  if (typeof globalThis.TransformStream !== "function") {
+    globalThis.TransformStream =
+      NodeTransformStream as unknown as typeof TransformStream;
+  }
+}

--- a/packages/connect-core/src/protocol-connect/end-stream.spec.ts
+++ b/packages/connect-core/src/protocol-connect/end-stream.spec.ts
@@ -17,12 +17,9 @@ import { endStreamFromJson, endStreamToJson } from "./end-stream.js";
 import { ConnectError } from "../connect-error.js";
 import { Code } from "../code.js";
 import { errorToJson } from "./error-to-json.js";
-import { Headers as UndiciHeaders } from "undici";
+import { node16FetchHeadersPolyfill } from "../node16-polyfill-helper.spec.js";
 
-// TODO we need to replace all Headers ctor calls in our code or require Node.js >= v18
-if (typeof globalThis.Headers !== "function") {
-  globalThis.Headers = UndiciHeaders as unknown as typeof Headers;
-}
+node16FetchHeadersPolyfill();
 
 describe("endStreamFromJson()", function () {
   it("should parse expected", function () {

--- a/packages/connect-core/src/protocol-connect/end-stream.ts
+++ b/packages/connect-core/src/protocol-connect/end-stream.ts
@@ -22,7 +22,7 @@ import { newParseError } from "./new-parse-error.js";
 import { errorToJson } from "./error-to-json.js";
 import { appendHeaders } from "../http-headers.js";
 import { ConnectError } from "../connect-error.js";
-import type { Serialization } from "../serialization";
+import type { Serialization } from "../serialization.js";
 import { Code } from "../code.js";
 
 /**

--- a/packages/connect-core/src/stream-transform-story.spec.ts
+++ b/packages/connect-core/src/stream-transform-story.spec.ts
@@ -15,7 +15,6 @@
 import {
   createReadableByteStream,
   createReadableStream,
-  node16WhatwgStreamPolyfill,
   readAll,
   readAllBytes,
 } from "./whatwg-stream-helper.spec.js";
@@ -32,6 +31,7 @@ import type { Compression } from "./compression.js";
 import { encodeEnvelopes } from "./envelope.js";
 import { ConnectError } from "./connect-error.js";
 import { Code } from "./code.js";
+import { node16WhatwgStreamPolyfill } from "./node16-polyfill-helper.spec.js";
 
 node16WhatwgStreamPolyfill();
 

--- a/packages/connect-core/src/stream-transform.spec.ts
+++ b/packages/connect-core/src/stream-transform.spec.ts
@@ -15,7 +15,6 @@
 import {
   createReadableByteStream,
   createReadableStream,
-  node16WhatwgStreamPolyfill,
   readAll,
   readAllBytes,
 } from "./whatwg-stream-helper.spec.js";
@@ -32,6 +31,7 @@ import type { Compression } from "./compression.js";
 import { encodeEnvelopes } from "./envelope.js";
 import { ConnectError } from "./connect-error.js";
 import { Code } from "./code.js";
+import { node16WhatwgStreamPolyfill } from "./node16-polyfill-helper.spec.js";
 
 node16WhatwgStreamPolyfill();
 

--- a/packages/connect-core/src/whatwg-stream-helper.spec.ts
+++ b/packages/connect-core/src/whatwg-stream-helper.spec.ts
@@ -12,33 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {
-  ReadableStream as NodeReadableStream,
-  TransformStream as NodeTransformStream,
-  WritableStream as NodeWritableStream,
-} from "stream/web";
-
-/**
- * Make the WHATWG stream implementation of Node.js v16 available in the global
- * scope.
- */
-export function node16WhatwgStreamPolyfill() {
-  // node >= v16 has an implementation for WHATWG streams, but doesn't expose
-  // them in the global scope, nor globalThis.
-  if (typeof globalThis.ReadableStream !== "function") {
-    globalThis.ReadableStream =
-      NodeReadableStream as unknown as typeof ReadableStream;
-  }
-  if (typeof globalThis.WritableStream !== "function") {
-    globalThis.WritableStream =
-      NodeWritableStream as unknown as typeof WritableStream;
-  }
-  if (typeof globalThis.TransformStream !== "function") {
-    globalThis.TransformStream =
-      NodeTransformStream as unknown as typeof TransformStream;
-  }
-}
-
 /**
  * Create a WHATWG ReadableStream from a Uint8Array for usage in tests.
  */

--- a/packages/connect-node/src/private/compression-negotiate.ts
+++ b/packages/connect-node/src/private/compression-negotiate.ts
@@ -15,6 +15,8 @@
 import { Code, ConnectError, Compression } from "@bufbuild/connect-core";
 
 /**
+ * @deprecated use compressionNegotiate from @bufbuild/core
+ *
  * compressionNegotiate validates the request encoding and determines
  * the accepted response encoding.
  *


### PR DESCRIPTION
This moves the function compressionNegotiate() to @bufbuild/connect-core and adds tests.

This also fixes a dependency of @bufbuild/connect-core ("undici" is a dev dependency). This also re-organizes the polyfills used in tests for better clarity.