### PR TITLE
Propagate downstream errors in asynchronous iterables

### DIFF
--- a/packages/connect-core/src/async-iterable.spec.ts
+++ b/packages/connect-core/src/async-iterable.spec.ts
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import {
-  makeIterableAbortable,
   pipe,
   pipeTo,
   transformCatch,
@@ -24,6 +23,7 @@ import {
   transformReadAllBytes,
   transformSerializeEnvelope,
   transformSplitEnvelope,
+  makeIterableAbortable,
 } from "./async-iterable.js";
 import type { Serialization } from "./serialization.js";
 import {

--- a/packages/connect-core/src/async-iterable.spec.ts
+++ b/packages/connect-core/src/async-iterable.spec.ts
@@ -130,7 +130,7 @@ describe("pipe()", function () {
     expect(sum).toBe(9);
   });
 
-  describe("with error raising consumer", function () {
+  describe("with error-raising consumer", function () {
     const sourceLog: string[] = [];
     beforeEach(function () {
       sourceLog.splice(0);
@@ -245,7 +245,7 @@ describe("pipeTo()", function () {
     expect(sum).toBe(9);
   });
 
-  describe("with error raising sink", function () {
+  describe("with error-raising sink", function () {
     const sourceLog: string[] = [];
     beforeEach(function () {
       sourceLog.splice(0);
@@ -358,7 +358,7 @@ describe("makeIterableAbortable()", function () {
       expect(sourceLog).toEqual(["yield a", "swallowed ERR", "finally"]);
     });
   });
-  describe("with error catching source", function () {
+  describe("with error-catching source", function () {
     // eslint-disable-next-line @typescript-eslint/require-await
     async function* source() {
       try {

--- a/packages/connect-core/src/async-iterable.ts
+++ b/packages/connect-core/src/async-iterable.ts
@@ -94,7 +94,7 @@ interface PipeOptions {
    * If this option is set to true, an error raised by the sink function given
    * to pipeTo() will raise the same error in the source iterable.
    *
-   * ``ts
+   * ```ts
    * async function source*() {
    *   const conn = await dbConn();
    *   try {

--- a/packages/connect-core/src/index.ts
+++ b/packages/connect-core/src/index.ts
@@ -81,4 +81,5 @@ export {
   pipeTo,
   sinkAll,
   sinkAllBytes,
+  makeIterableAbortable,
 } from "./async-iterable.js";


### PR DESCRIPTION
This adds the option `propagateDownStreamError?: boolean` to `pipe()` and `pipeTo()`.

For context: 

If iterators are chained, any error raised by the source or any transform travels down the stream. But if an error happens downstream, the source and transformations are left dangling:

```ts
async function source*() {
  const conn = await dbConn();
  yield await conn.query("SELECT 1"); // consumed downstream
  yield await conn.query("SELECT 2"); // never consumed
  conn.close(); // never runs
}
for await (const element of source()) {
  // let's say we try to write the element to disk, but the disk is full
  throw "err";
}
```

If this option is set to true, an error raised by the sink function given to pipeTo() will raise the same error in the source iterable.

```ts
async function source*() {
  const conn = await dbConn();
  try {
    yield await conn.query("SELECT 1"); // consumed downstream
    yield await conn.query("SELECT 2"); // never consumed
  } finally {
    conn.close(); // runs!
  }
}
await pipeTo(source(), async iterable => {
  for await (const element of source()) {
    // let's say we try to write the element to disk, but the disk is full
    throw "err";
  }
}, { propagateDownStreamError: true });
```

If this option is set to true with pipe(), the downstream consumer of the iterable returned by pipe() can abort the source iterable by calling throw() on the iterator.


For more context, see [this tc39 discussion](https://github.com/tc39/proposal-async-iteration/issues/126). This PR may not be the perfect solution, but it seems like a reasonable approach to get the abort behavior in streams that we need.