### PR TITLE
Start migrating clients to asynchronous iterables

### DIFF
--- a/packages/connect-node-test/src/node-universal-client.spec.ts
+++ b/packages/connect-node-test/src/node-universal-client.spec.ts
@@ -1,0 +1,230 @@
+// Copyright 2021-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { TestService } from "./gen/grpc/testing/test_connectweb.js";
+import {
+  StreamingOutputCallRequest,
+  StreamingOutputCallResponse,
+} from "./gen/grpc/testing/messages_pb.js";
+import { createTestServers } from "./helpers/testserver.js";
+import {
+  createJsonSerialization,
+  createMethodUrl,
+  pipe,
+  pipeTo,
+  transformJoinEnvelopes,
+  transformParseEnvelope,
+  transformSerializeEnvelope,
+  transformSplitEnvelope,
+} from "@bufbuild/connect-core";
+import {
+  createTrailerSerialization,
+  trailerFlag,
+} from "@bufbuild/connect-core/protocol-grpc-web";
+import {
+  createNodeHttp1Client,
+  createNodeHttp2Client,
+} from "@bufbuild/connect-node";
+
+// TODO remove after migrating node transports to this pattern
+describe("node client requests against", () => {
+  const servers = createTestServers();
+  beforeAll(async () => await servers.start());
+
+  servers.describeServers(
+    [
+      "@bufbuild/connect-node (h1)",
+      "@bufbuild/connect-node (h1 + tls)",
+      "connect-go (h1)",
+    ],
+    (server) => {
+      describe("with gRPC-web server-streaming", function () {
+        const method = TestService.methods.streamingOutputCall;
+        it("should return expected result", async function () {
+          const inputLog: string[] = [];
+          const outputLog: string[] = [];
+          // eslint-disable-next-line @typescript-eslint/require-await
+          async function* input() {
+            try {
+              inputLog.push("yield size 1");
+              yield new StreamingOutputCallRequest({
+                responseParameters: [{ size: 1 }],
+              });
+            } catch (e) {
+              inputLog.push("saw " + String(e));
+            } finally {
+              inputLog.push("finally");
+            }
+          }
+          const client = createNodeHttp1Client({
+            rejectUnauthorized: false,
+          });
+          const res = await client({
+            url: createMethodUrl(server.getUrl(), TestService, method),
+            method: "POST",
+            header: new Headers({
+              "Content-Type": "application/grpc-web+json",
+            }),
+            body: pipe(
+              input(),
+              transformSerializeEnvelope(
+                createJsonSerialization(method.I, {}),
+                Number.MAX_SAFE_INTEGER
+              ),
+              transformJoinEnvelopes(),
+              {
+                propagateDownStreamError: true,
+              }
+            ),
+          });
+          expect(res.status).toBe(200);
+          await pipeTo(
+            res.body,
+            transformSplitEnvelope(Number.MAX_SAFE_INTEGER),
+            transformParseEnvelope<StreamingOutputCallResponse, Headers>(
+              createJsonSerialization(method.O, {}),
+              trailerFlag,
+              createTrailerSerialization()
+            ),
+            async (iterable) => {
+              for await (const chunk of iterable) {
+                if (!chunk.end) {
+                  outputLog.push(
+                    `received size ${
+                      chunk.value.payload?.body.byteLength ?? "?"
+                    }`
+                  );
+                } else {
+                  outputLog.push("received end-stream");
+                }
+              }
+            },
+            {
+              propagateDownStreamError: false,
+            }
+          );
+          expect(listHeaderKeys(res.trailer).length).toBe(0);
+          expect(inputLog).toEqual(["yield size 1", "finally"]);
+          expect(outputLog).toEqual(["received size 1", "received end-stream"]);
+        });
+      });
+    }
+  );
+
+  servers.describeServers(
+    [
+      "@bufbuild/connect-node (h2c)",
+      "@bufbuild/connect-node (h2)",
+      "connect-go (h2)",
+    ],
+    (server) => {
+      describe("with gRPC-web bidi-streaming", function () {
+        const method = TestService.methods.fullDuplexCall;
+        it("should return expected result", async function () {
+          const inputLog: string[] = [];
+          const outputLog: string[] = [];
+          // eslint-disable-next-line @typescript-eslint/require-await
+          async function* input() {
+            try {
+              inputLog.push("yield size 1");
+              yield new StreamingOutputCallRequest({
+                responseParameters: [{ size: 1 }],
+              });
+              inputLog.push("yield size 2");
+              yield new StreamingOutputCallRequest({
+                responseParameters: [{ size: 2 }],
+              });
+              inputLog.push("yield size 3");
+              yield new StreamingOutputCallRequest({
+                responseParameters: [{ size: 3 }],
+              });
+            } catch (e) {
+              inputLog.push("saw " + String(e));
+            } finally {
+              inputLog.push("finally");
+            }
+          }
+          const client = createNodeHttp2Client(server.getUrl(), true, {
+            rejectUnauthorized: false,
+          });
+          const res = await client({
+            url: createMethodUrl(server.getUrl(), TestService, method),
+            method: "POST",
+            header: new Headers({
+              "Content-Type": "application/grpc-web+json",
+            }),
+            body: pipe(
+              input(),
+              transformSerializeEnvelope(
+                createJsonSerialization(method.I, {}),
+                Number.MAX_SAFE_INTEGER
+              ),
+              transformJoinEnvelopes(),
+              {
+                propagateDownStreamError: true,
+              }
+            ),
+          });
+          expect(res.status).toBe(200);
+          await pipeTo(
+            res.body,
+            transformSplitEnvelope(Number.MAX_SAFE_INTEGER),
+            transformParseEnvelope<StreamingOutputCallResponse, Headers>(
+              createJsonSerialization(method.O, {}),
+              trailerFlag,
+              createTrailerSerialization()
+            ),
+            async (iterable) => {
+              for await (const chunk of iterable) {
+                if (!chunk.end) {
+                  outputLog.push(
+                    `received size ${
+                      chunk.value.payload?.body.byteLength ?? "?"
+                    }`
+                  );
+                } else {
+                  outputLog.push("received end-stream");
+                }
+              }
+            },
+            {
+              propagateDownStreamError: false,
+            }
+          );
+          expect(listHeaderKeys(res.trailer).length).toBe(0);
+          expect(inputLog).toEqual([
+            "yield size 1",
+            "yield size 2",
+            "yield size 3",
+            "finally",
+          ]);
+          expect(outputLog).toEqual([
+            "received size 1",
+            "received size 2",
+            "received size 3",
+            "received end-stream",
+          ]);
+        });
+      });
+    }
+  );
+
+  afterAll(async () => await servers.stop());
+});
+
+function listHeaderKeys(header: Headers): string[] {
+  const keys: string[] = [];
+  header.forEach((_, key) => keys.push(key));
+  return keys;
+}

--- a/packages/connect-node/src/connect-handler.ts
+++ b/packages/connect-node/src/connect-handler.ts
@@ -72,8 +72,8 @@ import type {
 } from "./protocol-handler.js";
 import {
   UniversalHandlerFn,
-  UniversalRequest,
-  UniversalResponse,
+  UniversalServerRequest,
+  UniversalServerResponse,
   uResponseMethodNotAllowed,
   uResponseOk,
   uResponseUnsupportedMediaType,
@@ -136,8 +136,8 @@ function createUnaryHandler<I extends Message<I>, O extends Message<O>>(
   serialization: MethodSerializationLookup<I, O>
 ) {
   return async function handle(
-    req: UniversalRequest
-  ): Promise<UniversalResponse> {
+    req: UniversalServerRequest
+  ): Promise<UniversalServerResponse> {
     const type = parseContentType(req.header.get(headerContentType));
     if (type == undefined || type.stream) {
       return uResponseUnsupportedMediaType;
@@ -242,7 +242,7 @@ function createStreamHandler<I extends Message<I>, O extends Message<O>>(
   serialization: MethodSerializationLookup<I, O>,
   endStreamSerialization: Serialization<EndStreamResponse>
 ) {
-  return function handle(req: UniversalRequest): UniversalResponse {
+  return function handle(req: UniversalServerRequest): UniversalServerResponse {
     const type = parseContentType(req.header.get(headerContentType));
     if (type == undefined || !type.stream) {
       return uResponseUnsupportedMediaType;

--- a/packages/connect-node/src/connect-handler.ts
+++ b/packages/connect-node/src/connect-handler.ts
@@ -69,15 +69,15 @@ import {
 import type {
   ProtocolHandlerFact,
   ProtocolHandlerFactInit,
+} from "./protocol-handler.js";
+import {
   UniversalHandlerFn,
   UniversalRequest,
   UniversalResponse,
-} from "./protocol-handler.js";
-import {
   uResponseMethodNotAllowed,
   uResponseOk,
   uResponseUnsupportedMediaType,
-} from "./protocol-handler.js";
+} from "./private/universal.js";
 
 const protocolName = "connect";
 const methodPost = "POST";

--- a/packages/connect-node/src/connect-http-transport.ts
+++ b/packages/connect-node/src/connect-http-transport.ts
@@ -61,11 +61,11 @@ import {
 } from "./private/io.js";
 import type * as http from "http";
 import type * as https from "https";
-import { nodeHeaderToWebHeader } from "./private/node-universal.js";
 import { assert } from "./private/assert.js";
 import { compressionBrotli, compressionGzip } from "./compression.js";
 import { validateReadMaxBytesOption } from "./private/validate-read-max-bytes-option.js";
 import { getNodeRequest, makeNodeRequest } from "./private/node-request.js";
+import { nodeHeaderToWebHeader } from "./private/node-universal-header.js";
 
 export interface ConnectHttpTransportOptions {
   /**

--- a/packages/connect-node/src/connect-http2-transport.ts
+++ b/packages/connect-node/src/connect-http2-transport.ts
@@ -52,7 +52,6 @@ import type {
 } from "@bufbuild/protobuf";
 import type { ReadableStreamReadResultLike } from "./lib.dom.streams.js";
 import * as http2 from "http2";
-import { webHeaderToNodeHeaders } from "./private/node-universal.js";
 import { defer } from "./private/defer.js";
 import {
   end,
@@ -65,6 +64,7 @@ import {
 import { connectErrorFromNodeReason } from "./private/node-error.js";
 import { compressionBrotli, compressionGzip } from "./compression.js";
 import { validateReadMaxBytesOption } from "./private/validate-read-max-bytes-option.js";
+import { webHeaderToNodeHeaders } from "./private/node-universal-header.js";
 
 /**
  * Options used to configure the Connect transport.

--- a/packages/connect-node/src/grpc-handler.ts
+++ b/packages/connect-node/src/grpc-handler.ts
@@ -50,14 +50,14 @@ import {
 import type {
   ProtocolHandlerFact,
   ProtocolHandlerFactInit,
-  UniversalRequest,
-  UniversalResponse,
 } from "./protocol-handler.js";
 import {
+  UniversalRequest,
+  UniversalResponse,
   uResponseMethodNotAllowed,
   uResponseOk,
   uResponseUnsupportedMediaType,
-} from "./protocol-handler.js";
+} from "./private/universal.js";
 
 const protocolName = "grpc";
 const methodPost = "POST";

--- a/packages/connect-node/src/grpc-handler.ts
+++ b/packages/connect-node/src/grpc-handler.ts
@@ -52,8 +52,8 @@ import type {
   ProtocolHandlerFactInit,
 } from "./protocol-handler.js";
 import {
-  UniversalRequest,
-  UniversalResponse,
+  UniversalServerRequest,
+  UniversalServerResponse,
   uResponseMethodNotAllowed,
   uResponseOk,
   uResponseUnsupportedMediaType,
@@ -95,7 +95,7 @@ function createHandler<I extends Message<I>, O extends Message<O>>(
     opt.binaryOptions,
     opt.jsonOptions
   );
-  return function handle(req: UniversalRequest): UniversalResponse {
+  return function handle(req: UniversalServerRequest): UniversalServerResponse {
     const type = parseContentType(req.header.get(headerContentType));
     if (type == undefined) {
       return uResponseUnsupportedMediaType;

--- a/packages/connect-node/src/grpc-http-transport.ts
+++ b/packages/connect-node/src/grpc-http-transport.ts
@@ -49,7 +49,6 @@ import type {
   ServiceType,
 } from "@bufbuild/protobuf";
 import { connectErrorFromNodeReason } from "./private/node-error.js";
-import { nodeHeaderToWebHeader } from "./private/node-universal.js";
 import { assert } from "./private/assert.js";
 import {
   end,
@@ -62,6 +61,7 @@ import { compressionGzip, compressionBrotli } from "./compression.js";
 import { validateReadMaxBytesOption } from "./private/validate-read-max-bytes-option.js";
 
 import { getNodeRequest, makeNodeRequest } from "./private/node-request.js";
+import { nodeHeaderToWebHeader } from "./private/node-universal-header.js";
 
 export interface GrpcHttpTransportOptions {
   /**

--- a/packages/connect-node/src/grpc-http2-transport.ts
+++ b/packages/connect-node/src/grpc-http2-transport.ts
@@ -55,10 +55,10 @@ import {
   readResponseTrailer,
   write,
 } from "./private/io.js";
-import { webHeaderToNodeHeaders } from "./private/node-universal.js";
 import { connectErrorFromNodeReason } from "./private/node-error.js";
 import { compressionBrotli, compressionGzip } from "./compression.js";
 import { validateReadMaxBytesOption } from "./private/validate-read-max-bytes-option.js";
+import { webHeaderToNodeHeaders } from "./private/node-universal-header.js";
 
 /**
  * Options used to configure the gRPC-web transport.

--- a/packages/connect-node/src/grpc-web-handler.ts
+++ b/packages/connect-node/src/grpc-web-handler.ts
@@ -56,8 +56,8 @@ import type {
   ProtocolHandlerFactInit,
 } from "./protocol-handler.js";
 import {
-  UniversalRequest,
-  UniversalResponse,
+  UniversalServerRequest,
+  UniversalServerResponse,
   uResponseMethodNotAllowed,
   uResponseOk,
   uResponseUnsupportedMediaType,
@@ -101,7 +101,7 @@ function createHandler<I extends Message<I>, O extends Message<O>>(
     opt.binaryOptions,
     opt.jsonOptions
   );
-  return function handle(req: UniversalRequest): UniversalResponse {
+  return function handle(req: UniversalServerRequest): UniversalServerResponse {
     const type = parseContentType(req.header.get(headerContentType));
     if (type == undefined || type.text) {
       return uResponseUnsupportedMediaType;

--- a/packages/connect-node/src/grpc-web-handler.ts
+++ b/packages/connect-node/src/grpc-web-handler.ts
@@ -54,14 +54,14 @@ import {
 import type {
   ProtocolHandlerFact,
   ProtocolHandlerFactInit,
-  UniversalRequest,
-  UniversalResponse,
 } from "./protocol-handler.js";
 import {
+  UniversalRequest,
+  UniversalResponse,
   uResponseMethodNotAllowed,
   uResponseOk,
   uResponseUnsupportedMediaType,
-} from "./protocol-handler.js";
+} from "./private/universal.js";
 
 const protocolName = "grpc-web";
 const methodPost = "POST";

--- a/packages/connect-node/src/grpc-web-http-transport.ts
+++ b/packages/connect-node/src/grpc-web-http-transport.ts
@@ -50,7 +50,6 @@ import type {
 } from "@bufbuild/protobuf";
 import type * as http from "http";
 import type * as https from "https";
-import { nodeHeaderToWebHeader } from "./private/node-universal.js";
 import { connectErrorFromNodeReason } from "./private/node-error.js";
 import { end, readEnvelope, write } from "./private/io.js";
 import { assert } from "./private/assert.js";
@@ -59,6 +58,7 @@ import type { ReadableStreamReadResultLike } from "./lib.dom.streams.js";
 import { compressionBrotli, compressionGzip } from "./compression.js";
 import { validateReadMaxBytesOption } from "./private/validate-read-max-bytes-option.js";
 import { getNodeRequest, makeNodeRequest } from "./private/node-request.js";
+import { nodeHeaderToWebHeader } from "./private/node-universal-header.js";
 
 export interface GrpcWebHttpTransportOptions {
   /**

--- a/packages/connect-node/src/grpc-web-http2-transport.ts
+++ b/packages/connect-node/src/grpc-web-http2-transport.ts
@@ -52,10 +52,10 @@ import * as http2 from "http2";
 import type { ReadableStreamReadResultLike } from "./lib.dom.streams.js";
 import { defer } from "./private/defer.js";
 import { end, readEnvelope, readResponseHeader, write } from "./private/io.js";
-import { webHeaderToNodeHeaders } from "./private/node-universal.js";
 import { connectErrorFromNodeReason } from "./private/node-error.js";
 import { compressionBrotli, compressionGzip } from "./compression.js";
 import { validateReadMaxBytesOption } from "./private/validate-read-max-bytes-option.js";
+import { webHeaderToNodeHeaders } from "./private/node-universal-header.js";
 
 /**
  * Options used to configure the gRPC-web transport.

--- a/packages/connect-node/src/handler.ts
+++ b/packages/connect-node/src/handler.ts
@@ -19,35 +19,35 @@ import {
   ConnectError,
   createMethodUrl,
 } from "@bufbuild/connect-core";
-import type {
+import {
   BinaryReadOptions,
   BinaryWriteOptions,
   JsonReadOptions,
   JsonWriteOptions,
   MethodInfo,
+  MethodKind,
   ServiceType,
 } from "@bufbuild/protobuf";
-import { MethodKind } from "@bufbuild/protobuf";
 import { createImplSpec, MethodImpl, ServiceImpl } from "./implementation.js";
 import type {
   ProtocolHandlerFact,
   ProtocolHandlerFactInit,
-  UniversalRequest,
 } from "./protocol-handler.js";
 import {
-  NodeHandler,
+  NodeHandlerFn,
   universalHandlerToNodeHandler,
-} from "./private/node-universal.js";
+} from "./private/node-universal-handler.js";
 import { compressionBrotli, compressionGzip } from "./compression.js";
 import { createGrpcHandlerProtocol } from "./grpc-handler.js";
 import { createGrpcWebProtocolHandler } from "./grpc-web-handler.js";
 import { createConnectProtocolHandler } from "./connect-handler.js";
 import {
+  UniversalRequest,
   uResponseMethodNotAllowed,
   uResponseNotFound,
   uResponseUnsupportedMediaType,
   uResponseVersionNotSupported,
-} from "./protocol-handler.js";
+} from "./private/universal.js";
 
 /**
  * Handler handles a Node.js request for one specific RPC - a procedure
@@ -56,7 +56,7 @@ import {
  * That this function is compatible with http.RequestListener and its
  * equivalent for http2.
  */
-export type Handler = NodeHandler & {
+export type Handler = NodeHandlerFn & {
   /**
    * The names of the protocols this handler implements.
    */
@@ -213,7 +213,7 @@ export function createHandler<M extends MethodInfo>(
 export function mergeHandlers(
   handlers: Handler[],
   options?: MergeHandlersOptions
-): NodeHandler {
+): NodeHandlerFn {
   const prefix = options?.requestPathPrefix ?? "";
   const fallback =
     options?.fallback ??
@@ -246,7 +246,7 @@ interface MergeHandlersOptions {
    * If none of the handler request paths match, a 404 is served. This option
    * can provide a custom fallback for this case.
    */
-  fallback?: NodeHandler;
+  fallback?: NodeHandlerFn;
 }
 
 /**

--- a/packages/connect-node/src/handler.ts
+++ b/packages/connect-node/src/handler.ts
@@ -42,7 +42,7 @@ import { createGrpcHandlerProtocol } from "./grpc-handler.js";
 import { createGrpcWebProtocolHandler } from "./grpc-web-handler.js";
 import { createConnectProtocolHandler } from "./connect-handler.js";
 import {
-  UniversalRequest,
+  UniversalServerRequest,
   uResponseMethodNotAllowed,
   uResponseNotFound,
   uResponseUnsupportedMediaType,
@@ -142,7 +142,7 @@ export function createHandler<M extends MethodInfo>(
   const opt = internalHandlerOptions(options);
   const handlers = opt.protocols.map((fact) => fact(spec));
 
-  function protocolNegotiatingHandler(request: UniversalRequest) {
+  function protocolNegotiatingHandler(request: UniversalServerRequest) {
     if (
       method.kind == MethodKind.BiDiStreaming &&
       request.httpVersion.startsWith("1.")

--- a/packages/connect-node/src/index.ts
+++ b/packages/connect-node/src/index.ts
@@ -51,3 +51,9 @@ export {
   createHandlers,
   mergeHandlers,
 } from "./handler.js";
+
+// TODO remove temporary export
+export {
+  createNodeHttp1Client,
+  createNodeHttp2Client,
+} from "./private/node-universal-client.js";

--- a/packages/connect-node/src/private/io.ts
+++ b/packages/connect-node/src/private/io.ts
@@ -19,7 +19,7 @@ import { assert } from "./assert.js";
 import type { ReadableStreamReadResultLike } from "../lib.dom.streams.js";
 import { Code, ConnectError, EnvelopedMessage } from "@bufbuild/connect-core";
 import type { JsonValue } from "@bufbuild/protobuf";
-import { nodeHeaderToWebHeader } from "./node-universal.js";
+import { nodeHeaderToWebHeader } from "./node-universal-header.js";
 
 /**
  * @deprecated

--- a/packages/connect-node/src/private/node-request.ts
+++ b/packages/connect-node/src/private/node-request.ts
@@ -16,7 +16,7 @@ import * as http from "http";
 import * as https from "https";
 import type { AnyMessage, Message } from "@bufbuild/protobuf";
 import type { StreamingRequest, UnaryRequest } from "@bufbuild/connect-core";
-import { webHeaderToNodeHeaders } from "./node-universal.js";
+import { webHeaderToNodeHeaders } from "./node-universal-header.js";
 
 interface NodeRequestOptions<
   I extends Message<I> = AnyMessage,

--- a/packages/connect-node/src/private/node-universal-client.ts
+++ b/packages/connect-node/src/private/node-universal-client.ts
@@ -1,0 +1,288 @@
+// Copyright 2021-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as http2 from "http2";
+import * as http from "http";
+import * as https from "https";
+import {
+  AsyncIterableSink,
+  Code,
+  ConnectError,
+  pipeTo,
+} from "@bufbuild/connect-core";
+import type {
+  UniversalClientFn,
+  UniversalClientRequest,
+  UniversalClientResponse,
+} from "./universal.js";
+import {
+  nodeHeaderToWebHeader,
+  webHeaderToNodeHeaders,
+} from "./node-universal-header.js";
+
+/**
+ * Create an HTTP client using the Node.js `http` or `https` package.
+ *
+ * The HTTP client is a simple function conforming to the type UniversalClientFn.
+ * It takes an UniversalClientRequest as an argument, and returns a promise for
+ * an UniversalClientResponse.
+ */
+export function createNodeHttp1Client(
+  httpOptions:
+    | Omit<http.RequestOptions, "signal">
+    | Omit<https.RequestOptions, "signal">
+    | undefined
+): UniversalClientFn {
+  return async function request(
+    req: UniversalClientRequest
+  ): Promise<UniversalClientResponse> {
+    const nodeRequest: http.ClientRequest = await new Promise(
+      (resolve, error) => {
+        let request: http.ClientRequest;
+        const requestOptions = {
+          ...httpOptions,
+          headers: webHeaderToNodeHeaders(req.header),
+          method: req.method,
+          signal: req.signal,
+        };
+        if (new URL(req.url).protocol.startsWith("https")) {
+          request = https.request(req.url, requestOptions);
+        } else {
+          request = http.request(req.url, requestOptions);
+        }
+        request.once("socket", (socket) => {
+          socket.once("connect", connect);
+          socket.once("error", error);
+
+          function connect() {
+            socket.off("error", rejectError);
+            resolve(request);
+          }
+
+          function rejectError(err: Error) {
+            socket.off("connect", connect);
+            error(err);
+          }
+        });
+      }
+    );
+    if (req.body == undefined) {
+      await new Promise<void>((resolve) => {
+        nodeRequest.end(resolve);
+      });
+    } else {
+      await pipeTo(req.body, createRequestSink(nodeRequest), {
+        propagateDownStreamError: true,
+      });
+    }
+    nodeRequest.removeAllListeners();
+    return new Promise<UniversalClientResponse>((resolve, reject) => {
+      nodeRequest.on("error", (args) => {
+        reject(args);
+      });
+      nodeRequest.on("response", (nodeResponse) => {
+        const status = nodeResponse.statusCode ?? 0;
+        const header = nodeHeaderToWebHeader(nodeResponse.headers);
+        const trailer = new Headers();
+        resolve({
+          status,
+          header,
+          body: read(nodeResponse, () => {
+            nodeHeaderToWebHeader(nodeResponse.trailers).forEach((value, key) => {
+              trailer.set(key, value);
+            });
+            nodeResponse.removeAllListeners();
+          }),
+          trailer,
+        });
+      });
+    });
+  };
+}
+
+/**
+ * Create an HTTP client using the Node.js `http2` package.
+ *
+ * Note that the client is bound to the authority, and by default, it will close
+ * the HTTP/2 session after the response is read to the end.
+ *
+ * The HTTP client is a simple function conforming to the type UniversalClientFn.
+ * It takes an UniversalClientRequest as an argument, and returns a promise for
+ * an UniversalClientResponse.
+ */
+export function createNodeHttp2Client(
+  authority: URL | string,
+  keepSessionOpen: boolean,
+  http2Options:
+    | http2.ClientSessionOptions
+    | http2.SecureClientSessionOptions
+    | undefined
+): UniversalClientFn {
+  const origin = new URL(authority).origin;
+  let lastSession: http2.ClientHttp2Session | undefined;
+  async function connect(): Promise<http2.ClientHttp2Session> {
+    if (
+      keepSessionOpen &&
+      lastSession !== undefined &&
+      !lastSession.closed &&
+      !lastSession.destroyed
+    ) {
+      return lastSession;
+    }
+    return (lastSession = await new Promise<http2.ClientHttp2Session>(
+      (resolve, reject) => {
+        const s = http2.connect(
+          origin,
+          {
+            ...http2Options,
+          },
+          (s) => resolve(s)
+        );
+        s.on("error", (err) => reject(err));
+      }
+    ));
+  }
+  return async function request(
+    req: UniversalClientRequest
+  ): Promise<UniversalClientResponse> {
+    if (new URL(req.url).origin !== origin) {
+      throw new ConnectError(
+        `cannot make a request to ${
+          new URL(req.url).origin
+        }: the http2 session is connected to ${origin}`,
+        Code.Internal
+      );
+    }
+    const session = await connect();
+    return new Promise<UniversalClientResponse>((resolve, reject) => {
+      const stream = session.request(
+        {
+          ...webHeaderToNodeHeaders(req.header),
+          ":method": req.method,
+          ":path": new URL(req.url).pathname,
+        },
+        {
+          signal: req.signal,
+        }
+      );
+      stream.on("error", (e) => {
+        reject(e);
+        cleanup();
+      });
+      const trailer = new Headers();
+      stream.on(
+        "trailers",
+        (args: http2.IncomingHttpHeaders & http2.IncomingHttpStatusHeader) => {
+          nodeHeaderToWebHeader(args).forEach((value, key) => {
+            trailer.set(key, value);
+          });
+        }
+      );
+      if (req.body == undefined) {
+        stream.end();
+      } else {
+        // we rely on propagation of the error to the source iterable
+        void pipeTo(req.body, createRequestSink(stream), {
+          propagateDownStreamError: true,
+        });
+      }
+      stream.on("response", (headers) => {
+        const status = headers[":status"] ?? 0;
+        const header = nodeHeaderToWebHeader(headers);
+        const response: UniversalClientResponse = {
+          status,
+          header,
+          body: read(stream, cleanup),
+          trailer,
+        };
+        resolve(response);
+      });
+      function cleanup() {
+        stream.removeAllListeners();
+        if (!keepSessionOpen) {
+          session.close();
+        }
+      }
+    });
+  };
+}
+
+async function* read(
+  readable: http.IncomingMessage | http2.ClientHttp2Stream,
+  finallyFn: undefined | (() => void) |(() => Promise<void>),
+): AsyncIterable<Uint8Array> {
+  try {
+    for await (const chunk of readable) {
+      yield chunk;
+    }
+  } finally {
+    if (finallyFn !== undefined) {
+      await finallyFn();
+    }
+  }
+}
+
+function createRequestSink(
+  nodeRequest: http.ClientRequest | http2.ClientHttp2Stream
+): AsyncIterableSink<Uint8Array> {
+  return function write(iterable: AsyncIterable<Uint8Array>): Promise<void> {
+    const it = iterable[Symbol.asyncIterator]();
+
+    return new Promise((resolve, reject) => {
+      nodeRequest.on("error", error);
+      nodeRequest.on("drain", drain);
+      nodeRequest.on("end", complete);
+
+      writeNext();
+
+      function complete() {
+        nodeRequest.off("error", error);
+        nodeRequest.off("drain", drain);
+        nodeRequest.off("end", complete);
+        resolve();
+      }
+
+      function error(reason: unknown) {
+        nodeRequest.off("drain", error);
+        nodeRequest.off("drain", drain);
+        nodeRequest.off("end", complete);
+        reject(reason);
+      }
+
+      function drain() {
+        writeNext();
+      }
+
+      function writeNext() {
+        it.next().then((r) => {
+          if (r.done === true) {
+            nodeRequest.end(complete);
+            return;
+          }
+          const flushed = nodeRequest.write(r.value, "binary", function (e) {
+            if (e) {
+              error(e);
+            }
+          });
+          // flushed == false: the stream wishes for the calling code to wait for
+          // the 'drain' event to be emitted before continuing to write additional
+          // data.
+          if (flushed) {
+            writeNext();
+          }
+        }, error);
+      }
+    });
+  };
+}

--- a/packages/connect-node/src/private/node-universal-client.ts
+++ b/packages/connect-node/src/private/node-universal-client.ts
@@ -99,9 +99,11 @@ export function createNodeHttp1Client(
           status,
           header,
           body: read(nodeResponse, () => {
-            nodeHeaderToWebHeader(nodeResponse.trailers).forEach((value, key) => {
-              trailer.set(key, value);
-            });
+            nodeHeaderToWebHeader(nodeResponse.trailers).forEach(
+              (value, key) => {
+                trailer.set(key, value);
+              }
+            );
             nodeResponse.removeAllListeners();
           }),
           trailer,
@@ -220,7 +222,7 @@ export function createNodeHttp2Client(
 
 async function* read(
   readable: http.IncomingMessage | http2.ClientHttp2Stream,
-  finallyFn: undefined | (() => void) |(() => Promise<void>),
+  finallyFn: undefined | (() => void) | (() => Promise<void>)
 ): AsyncIterable<Uint8Array> {
   try {
     for await (const chunk of readable) {

--- a/packages/connect-node/src/private/node-universal-handler.ts
+++ b/packages/connect-node/src/private/node-universal-handler.ts
@@ -15,22 +15,26 @@
 import type * as http from "http";
 import type * as http2 from "http2";
 import { write } from "./io.js";
+import {
+  nodeHeaderToWebHeader,
+  webHeaderToNodeHeaders,
+} from "./node-universal-header.js";
 import type {
   UniversalHandlerFn,
   UniversalRequest,
   UniversalResponse,
-} from "../protocol-handler.js";
+} from "./universal.js";
 
 /**
- * NodeHandler is compatible with http.RequestListener and its equivalent
+ * NodeHandlerFn is compatible with http.RequestListener and its equivalent
  * for http2.
  */
-export type NodeHandler = (
-  request: NodeRequest,
-  response: NodeResponse
+export type NodeHandlerFn = (
+  request: NodeServerRequest,
+  response: NodeServerResponse
 ) => void;
-type NodeRequest = http.IncomingMessage | http2.Http2ServerRequest;
-type NodeResponse = http.ServerResponse | http2.Http2ServerResponse;
+type NodeServerRequest = http.IncomingMessage | http2.Http2ServerRequest;
+type NodeServerResponse = http.ServerResponse | http2.Http2ServerResponse;
 
 /**
  * Convert a universal handler to a Node.js handler function.
@@ -38,16 +42,19 @@ type NodeResponse = http.ServerResponse | http2.Http2ServerResponse;
 export function universalHandlerToNodeHandler(
   universalHandler: UniversalHandlerFn,
   onInternalError: (reason: unknown) => void
-): NodeHandler {
-  return function nodeHandler(req: NodeRequest, res: NodeResponse): void {
+): NodeHandlerFn {
+  return function nodeHandler(
+    req: NodeServerRequest,
+    res: NodeServerResponse
+  ): void {
     runHandler(universalHandler, req, res).catch(onInternalError);
   };
 }
 
 async function runHandler(
   universalHandler: UniversalHandlerFn,
-  nodeRequest: NodeRequest,
-  nodeResponse: http.ServerResponse | http2.Http2ServerResponse
+  nodeRequest: NodeServerRequest,
+  nodeResponse: NodeServerResponse
 ) {
   const universalResponse = await universalHandler(
     universalRequestFromNodeRequest(nodeRequest)
@@ -56,7 +63,7 @@ async function runHandler(
 }
 
 function universalRequestFromNodeRequest(
-  nodeRequest: NodeRequest
+  nodeRequest: NodeServerRequest
 ): UniversalRequest {
   return {
     httpVersion: nodeRequest.httpVersion,
@@ -68,7 +75,7 @@ function universalRequestFromNodeRequest(
 
 async function universalResponseToNodeResponse(
   universalResponse: UniversalResponse,
-  nodeResponse: NodeResponse
+  nodeResponse: NodeServerResponse
 ): Promise<void> {
   if (universalResponse.body instanceof Uint8Array) {
     nodeResponse.writeHead(
@@ -78,6 +85,9 @@ async function universalResponseToNodeResponse(
     await write(nodeResponse, universalResponse.body);
   } else if (universalResponse.body !== undefined) {
     for await (const chunk of universalResponse.body) {
+      // we deliberately send headers *in* this loop, not before,
+      // because we have to give the implementation a chance to
+      // set response headers
       if (!nodeResponse.headersSent) {
         nodeResponse.writeHead(
           universalResponse.status,
@@ -103,71 +113,9 @@ async function universalResponseToNodeResponse(
 }
 
 async function* asyncIterableFromNodeServerRequest(
-  request: NodeRequest
+  request: NodeServerRequest
 ): AsyncIterable<Uint8Array> {
   for await (const chunk of request) {
     yield chunk;
   }
-}
-
-export function nodeHeaderToWebHeader(
-  nodeHeaders:
-    | http.OutgoingHttpHeaders
-    | http.IncomingHttpHeaders
-    | http2.IncomingHttpHeaders
-    | http.IncomingMessage["trailers"]
-): Headers {
-  const header = new Headers();
-  for (const [k, v] of Object.entries(nodeHeaders)) {
-    if (k.startsWith(":")) {
-      continue;
-    }
-    if (v === undefined) {
-      continue;
-    }
-    if (typeof v == "string") {
-      header.append(k, v);
-    } else if (typeof v == "number") {
-      header.append(k, String(v));
-    } else {
-      for (const e of v) {
-        header.append(k, e);
-      }
-    }
-  }
-  return header;
-}
-
-export function webHeaderToNodeHeaders(
-  headersInit: HeadersInit
-): http.OutgoingHttpHeaders;
-export function webHeaderToNodeHeaders(
-  headersInit: HeadersInit | undefined
-): undefined;
-export function webHeaderToNodeHeaders(
-  headersInit: HeadersInit | undefined
-): http.OutgoingHttpHeaders | undefined {
-  if (headersInit === undefined) {
-    return undefined;
-  }
-  const o = Object.create(null) as http.OutgoingHttpHeaders;
-  if (Array.isArray(headersInit)) {
-    for (const [key, value] of headersInit) {
-      const k = key.toLowerCase();
-      o[k] = value;
-    }
-  } else if ("forEach" in headersInit) {
-    if (typeof headersInit.forEach == "function") {
-      headersInit.forEach((value, key) => {
-        const k = key.toLowerCase();
-        o[k] = value;
-      });
-    }
-  } else {
-    for (const [key, value] of Object.entries<string>(headersInit)) {
-      const k = key.toLowerCase();
-      o[k] = value;
-    }
-  }
-  return o;
 }

--- a/packages/connect-node/src/private/node-universal-handler.ts
+++ b/packages/connect-node/src/private/node-universal-handler.ts
@@ -21,8 +21,8 @@ import {
 } from "./node-universal-header.js";
 import type {
   UniversalHandlerFn,
-  UniversalRequest,
-  UniversalResponse,
+  UniversalServerRequest,
+  UniversalServerResponse,
 } from "./universal.js";
 
 /**
@@ -64,7 +64,7 @@ async function runHandler(
 
 function universalRequestFromNodeRequest(
   nodeRequest: NodeServerRequest
-): UniversalRequest {
+): UniversalServerRequest {
   return {
     httpVersion: nodeRequest.httpVersion,
     method: nodeRequest.method ?? "",
@@ -74,7 +74,7 @@ function universalRequestFromNodeRequest(
 }
 
 async function universalResponseToNodeResponse(
-  universalResponse: UniversalResponse,
+  universalResponse: UniversalServerResponse,
   nodeResponse: NodeServerResponse
 ): Promise<void> {
   if (universalResponse.body instanceof Uint8Array) {

--- a/packages/connect-node/src/private/node-universal-header.ts
+++ b/packages/connect-node/src/private/node-universal-header.ts
@@ -1,0 +1,93 @@
+// Copyright 2021-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type * as http from "http";
+import type * as http2 from "http2";
+
+/**
+ * Convert a Node.js header object to a fetch API Headers object.
+ *
+ * This function works for Node.js incoming our outgoing headers, and for the
+ * http and the http2 package.
+ *
+ * HTTP/2 pseudo-headers (:method, :path, etc.) are stripped.
+ */
+export function nodeHeaderToWebHeader(
+  nodeHeaders:
+    | http.OutgoingHttpHeaders
+    | http.IncomingHttpHeaders
+    | http2.IncomingHttpHeaders
+    | http.IncomingMessage["trailers"]
+): Headers {
+  const header = new Headers();
+  for (const [k, v] of Object.entries(nodeHeaders)) {
+    if (k.startsWith(":")) {
+      continue;
+    }
+    if (v === undefined) {
+      continue;
+    }
+    if (typeof v == "string") {
+      header.append(k, v);
+    } else if (typeof v == "number") {
+      header.append(k, String(v));
+    } else {
+      for (const e of v) {
+        header.append(k, e);
+      }
+    }
+  }
+  return header;
+}
+
+/**
+ * Convert a fetch API Headers object to a Node.js headers object.
+ * Convert a Node.js header object to a fetch API Headers object.
+ *
+ * This function works for Node.js incoming our outgoing headers, and for the
+ * http and the http2 package.
+ */
+export function webHeaderToNodeHeaders(
+  headersInit: HeadersInit
+): http.OutgoingHttpHeaders;
+export function webHeaderToNodeHeaders(
+  headersInit: HeadersInit | undefined
+): http.OutgoingHttpHeaders | undefined;
+export function webHeaderToNodeHeaders(
+  headersInit: HeadersInit | undefined
+): http.OutgoingHttpHeaders | undefined {
+  if (headersInit === undefined) {
+    return undefined;
+  }
+  const o = Object.create(null) as http.OutgoingHttpHeaders;
+  if (Array.isArray(headersInit)) {
+    for (const [key, value] of headersInit) {
+      const k = key.toLowerCase();
+      o[k] = value;
+    }
+  } else if ("forEach" in headersInit) {
+    if (typeof headersInit.forEach == "function") {
+      headersInit.forEach((value, key) => {
+        const k = key.toLowerCase();
+        o[k] = value;
+      });
+    }
+  } else {
+    for (const [key, value] of Object.entries<string>(headersInit)) {
+      const k = key.toLowerCase();
+      o[k] = value;
+    }
+  }
+  return o;
+}

--- a/packages/connect-node/src/private/universal.ts
+++ b/packages/connect-node/src/private/universal.ts
@@ -44,13 +44,13 @@ export interface UniversalClientResponse {
  * A minimal abstraction of an HTTP handler.
  */
 export type UniversalHandlerFn = (
-  request: UniversalRequest
-) => UniversalResponse | Promise<UniversalResponse>;
+  request: UniversalServerRequest
+) => UniversalServerResponse | Promise<UniversalServerResponse>;
 
 /**
  * A minimal abstraction of an HTTP request on the server side.
  */
-export interface UniversalRequest {
+export interface UniversalServerRequest {
   httpVersion: string;
   method: string;
   header: Headers;
@@ -60,7 +60,7 @@ export interface UniversalRequest {
 /**
  * A minimal abstraction of an HTTP response on the server side.
  */
-export interface UniversalResponse {
+export interface UniversalServerResponse {
   status: number;
   header?: Headers;
   body?: AsyncIterable<Uint8Array> | Uint8Array;
@@ -70,30 +70,31 @@ export interface UniversalResponse {
 /**
  * HTTP 200 OK
  */
-export const uResponseOk: Readonly<UniversalResponse> = {
+export const uResponseOk: Readonly<UniversalServerResponse> = {
   status: 200,
 };
 /**
  * HTTP 404 Not Found
  */
-export const uResponseNotFound: Readonly<UniversalResponse> = {
+export const uResponseNotFound: Readonly<UniversalServerResponse> = {
   status: 404,
 };
 /**
  * HTTP 415 Unsupported Media Type
  */
-export const uResponseUnsupportedMediaType: Readonly<UniversalResponse> = {
-  status: 415,
-};
+export const uResponseUnsupportedMediaType: Readonly<UniversalServerResponse> =
+  {
+    status: 415,
+  };
 /**
  * HTTP 405 Method Not Allowed
  */
-export const uResponseMethodNotAllowed: Readonly<UniversalResponse> = {
+export const uResponseMethodNotAllowed: Readonly<UniversalServerResponse> = {
   status: 405,
 };
 /**
  * HTTP 505 Version Not Supported
  */
-export const uResponseVersionNotSupported: Readonly<UniversalResponse> = {
+export const uResponseVersionNotSupported: Readonly<UniversalServerResponse> = {
   status: 505,
 };

--- a/packages/connect-node/src/private/universal.ts
+++ b/packages/connect-node/src/private/universal.ts
@@ -1,0 +1,99 @@
+// Copyright 2021-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * A minimal abstraction of an HTTP client.
+ */
+export type UniversalClientFn = (
+  request: UniversalClientRequest
+) => Promise<UniversalClientResponse>;
+
+/**
+ * A minimal abstraction of an HTTP request on the client side.
+ */
+export interface UniversalClientRequest {
+  url: string;
+  method: string;
+  header: Headers;
+  body?: AsyncIterable<Uint8Array>;
+  signal?: AbortSignal;
+}
+
+/**
+ * A minimal abstraction of an HTTP request on the client side.
+ */
+export interface UniversalClientResponse {
+  status: number;
+  header: Headers;
+  body: AsyncIterable<Uint8Array>;
+  trailer: Headers;
+}
+
+/**
+ * A minimal abstraction of an HTTP handler.
+ */
+export type UniversalHandlerFn = (
+  request: UniversalRequest
+) => UniversalResponse | Promise<UniversalResponse>;
+
+/**
+ * A minimal abstraction of an HTTP request on the server side.
+ */
+export interface UniversalRequest {
+  httpVersion: string;
+  method: string;
+  header: Headers;
+  body: AsyncIterable<Uint8Array>;
+}
+
+/**
+ * A minimal abstraction of an HTTP response on the server side.
+ */
+export interface UniversalResponse {
+  status: number;
+  header?: Headers;
+  body?: AsyncIterable<Uint8Array> | Uint8Array;
+  trailer?: Headers;
+}
+
+/**
+ * HTTP 200 OK
+ */
+export const uResponseOk: Readonly<UniversalResponse> = {
+  status: 200,
+};
+/**
+ * HTTP 404 Not Found
+ */
+export const uResponseNotFound: Readonly<UniversalResponse> = {
+  status: 404,
+};
+/**
+ * HTTP 415 Unsupported Media Type
+ */
+export const uResponseUnsupportedMediaType: Readonly<UniversalResponse> = {
+  status: 415,
+};
+/**
+ * HTTP 405 Method Not Allowed
+ */
+export const uResponseMethodNotAllowed: Readonly<UniversalResponse> = {
+  status: 405,
+};
+/**
+ * HTTP 505 Version Not Supported
+ */
+export const uResponseVersionNotSupported: Readonly<UniversalResponse> = {
+  status: 505,
+};

--- a/packages/connect-node/src/protocol-handler.ts
+++ b/packages/connect-node/src/protocol-handler.ts
@@ -22,6 +22,7 @@ import type {
 } from "@bufbuild/protobuf";
 import type { ImplSpec } from "./implementation.js";
 import type { Compression } from "@bufbuild/connect-core";
+import type { UniversalHandlerFn } from "./private/universal.js";
 
 /**
  * Creates a handler function for an RPC definition and an RPC implementation,
@@ -89,65 +90,3 @@ export interface UniversalHandler extends UniversalHandlerFn {
    */
   supportedContentType: RegExp;
 }
-
-/**
- * A minimal abstraction of an HTTP handler.
- */
-export type UniversalHandlerFn = (
-  request: UniversalRequest
-) => UniversalResponse | Promise<UniversalResponse>;
-
-/**
- * A minimal abstraction of an HTTP request.
- */
-export interface UniversalRequest {
-  httpVersion: string;
-  method: string;
-  header: Headers;
-  body: AsyncIterable<Uint8Array>;
-}
-
-/**
- * A minimal abstraction of an HTTP response.
- */
-export interface UniversalResponse {
-  status: number;
-  header?: Headers;
-  body?: AsyncIterable<Uint8Array> | Uint8Array;
-  trailer?: Headers;
-}
-
-/**
- * HTTP 200 OK
- */
-export const uResponseOk: Readonly<UniversalResponse> = {
-  status: 200,
-};
-
-/**
- * HTTP 404 Not Found
- */
-export const uResponseNotFound: Readonly<UniversalResponse> = {
-  status: 404,
-};
-
-/**
- * HTTP 415 Unsupported Media Type
- */
-export const uResponseUnsupportedMediaType: Readonly<UniversalResponse> = {
-  status: 415,
-};
-
-/**
- * HTTP 405 Method Not Allowed
- */
-export const uResponseMethodNotAllowed: Readonly<UniversalResponse> = {
-  status: 405,
-};
-
-/**
- * HTTP 505 Version Not Supported
- */
-export const uResponseVersionNotSupported: Readonly<UniversalResponse> = {
-  status: 505,
-};


### PR DESCRIPTION
This adds a function signature for universal clients, similar to `UniversalHandlerFn` for handlers:

```ts
type UniversalClientFn = (request: UniversalClientRequest) => Promise<UniversalClientResponse>;
```

There are two new functions `createNodeHttp1Client()` and `createNodeHttp2Client()`, which return such a universal client function. 

Basic functionality is tested over http/1.1 and http/2 against connect-go and connect-node, with an ad-hoc implementation of gRPC-web.

I am sure we will change the actual implementations of the Node.js constructor functions going forward, but this should be a good start for migrating all Node.js transports to asynchronous iterables.