### PR TITLE
Add a README.md for @bufbuild/connect-node

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,14 +48,27 @@ available [fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API
 and the [Encoding API](https://developer.mozilla.org/en-US/docs/Web/API/Encoding_API).
 The library and the generated code are compatible with ES2017 and TypeScript 4.1.
 
-We are working on Connect for Node.js - join us on [Slack](https://buf.build/links/slack) 
-or see the [roadmap discussion](https://github.com/bufbuild/connect-web/discussions/315).
+
+## Connect for Node.js (Preview)
+
+With [@bufbuild/connect-node](https://www.npmjs.com/package/@bufbuild/connect-node), 
+you have the option to use the same clients from Connect-Web on Node.js v18. You can 
+also use it for servers using the Node.js `http`, `https`, or `http2` modules. 
+
+Connect-Node is still in preview, so we want your feedback! We’d love to learn about
+your use cases and what you’d like to do with Connect-Node. For example, do you plan
+to use it with React, Remix, or on the edge with Vercel’s Edge Runtime? You can reach
+us either through the [Buf Slack](https://buf.build/links/slack/) or by filing a
+[GitHub issue](https://github.com/bufbuild/connect-web/issues) and we’d be more than
+happy to chat!
 
 
 ## Packages
 
 - [@bufbuild/connect-web](https://www.npmjs.com/package/@bufbuild/connect-web):
-  Implements the Connect and gRPC-web protocols ([source code](packages/connect-web)).
+  Implements browser clients for the Connect and gRPC-web protocols ([source code](packages/connect-web)).
+- [@bufbuild/connect-node](https://www.npmjs.com/package/@bufbuild/connect-node):
+  Implements Node.js clients and servers for the Connect, gRPC-web, and gRPC protocols ([source code](packages/connect-node)).
 - [@bufbuild/protoc-gen-connect-web](https://www.npmjs.com/package/@bufbuild/protoc-gen-connect-web):
   Code generator plugin for the services in your schema ([source code](packages/protoc-gen-connect-web)).
 
@@ -64,6 +77,8 @@ or see the [roadmap discussion](https://github.com/bufbuild/connect-web/discussi
 
 * [connect-web-integration](https://github.com/bufbuild/connect-web-integration):
   Example projects using Connect-Web with various JS frameworks and tooling
+* [connect-query](https://github.com/bufbuild/connect-query):
+  TypeScript-first expansion pack for TanStack Query that gives you Protobuf superpowers
 * [connect-go](https://github.com/bufbuild/connect-go):
   Go implementation of gRPC, gRPC-Web, and Connect
 * [connect-demo](https://github.com/bufbuild/connect-demo):

--- a/packages/connect-core/README.md
+++ b/packages/connect-core/README.md
@@ -1,0 +1,9 @@
+# @bufbuild/connect-core
+
+This package exports primitives used by [@bufbuild/connect-web](https://www.npmjs.com/package/@bufbuild/connect-web) 
+and [@bufbuild/connect-node](https://www.npmjs.com/package/@bufbuild/connect-web).
+
+In general, we recommend not to depend on this package, and use the exports from
+[@bufbuild/connect-web](https://www.npmjs.com/package/@bufbuild/connect-web)
+and [@bufbuild/connect-node](https://www.npmjs.com/package/@bufbuild/connect-web)
+instead.

--- a/packages/connect-node-test/src/readme.spec.ts
+++ b/packages/connect-node-test/src/readme.spec.ts
@@ -1,0 +1,104 @@
+// Copyright 2021-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Message, MethodKind, proto3 } from "@bufbuild/protobuf";
+import * as http2 from "http2";
+import {
+  createGrpcTransport,
+  createHandler,
+  createPromiseClient,
+  mergeHandlers,
+} from "@bufbuild/connect-node";
+
+/* eslint-disable @typescript-eslint/require-await */
+
+describe("readme", function () {
+  interface SayR extends Message<SayR> {
+    sentence: string;
+  }
+  const SayR = proto3.makeMessageType<SayR>(
+    "buf.connect.demo.eliza.v1.SayRequest",
+    [{ no: 1, name: "sentence", kind: "scalar", T: 9 /* ScalarType.STRING */ }]
+  );
+
+  interface IntroduceRequest extends Message<IntroduceRequest> {
+    name: string;
+  }
+  const IntroduceRequest = proto3.makeMessageType<IntroduceRequest>(
+    "buf.connect.demo.eliza.v1.IntroduceRequest",
+    [{ no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ }]
+  );
+
+  const ElizaService = {
+    typeName: "buf.connect.demo.eliza.v1.ElizaService",
+    methods: {
+      say: {
+        name: "Say",
+        I: SayR,
+        O: SayR,
+        kind: MethodKind.Unary,
+      },
+      introduce: {
+        name: "Introduce",
+        I: IntroduceRequest,
+        O: SayR,
+        kind: MethodKind.ServerStreaming,
+      },
+    },
+  } as const;
+
+  it("should work as well", async function () {
+    let port = -1;
+
+    function startServer() {
+      return new Promise<http2.Http2Server>((resolve) => {
+        // A Node.js request listener that implements rpc Say(SayRequest) returns (SayResponse)
+        const handleSay = createHandler(
+          ElizaService,
+          ElizaService.methods.say,
+          async (req) => {
+            return {
+              sentence: `you said: ${req.sentence}`,
+            };
+          }
+        );
+
+        const server = http2
+          .createServer(mergeHandlers([handleSay]))
+          .listen(0, () => {
+            const a = server.address();
+            if (a !== null && typeof a !== "string") {
+              port = a.port;
+            }
+            resolve(server);
+          });
+      });
+    }
+
+    async function runClient() {
+      const transport = createGrpcTransport({
+        baseUrl: `http://localhost:${port}`,
+        httpVersion: "2",
+      });
+      const client = createPromiseClient(ElizaService, transport);
+      const res = await client.say({ sentence: "I feel happy." });
+      // console.log(res.sentence) // you said: I feel happy.
+      expect(res.sentence).toBe("you said: I feel happy.");
+    }
+
+    const server = await startServer();
+    await runClient();
+    server.close();
+  });
+});

--- a/packages/connect-node/README.md
+++ b/packages/connect-node/README.md
@@ -1,0 +1,97 @@
+# @bufbuild/connect-node (Preview)
+
+Connect-Node is a slim library for building browser and gRPC-compatible HTTP APIs. 
+The procedures are defined in a [Protocol Buffer](https://developers.google.com/protocol-buffers)
+schema, and Connect generates code and types for type-safe clients and handlers.
+Handlers and clients support three protocols: gRPC, gRPC-Web, and Connect's own protocol.
+
+The [Connect protocol](https://connect.build/docs/protocol/) is a simple,
+POST-only protocol that works over HTTP/1.1 or HTTP/2. It takes the best portions 
+of gRPC and gRPC-Web, including streaming, and packages them into a protocol that 
+works equally well in browsers, monoliths, and microservices. Calling a Connect 
+API is as easy as using `curl`.
+
+
+## Project status
+
+Connect-Node is still in preview, so we want your feedback! We’d love to learn about 
+your use cases and what you’d like to do with Connect-Node. For example, do you plan 
+to use it with React, Remix, or on the edge with Vercel’s Edge Runtime? You can reach 
+us either through the [Buf Slack](https://buf.build/links/slack/) or by filing a 
+[GitHub issue](https://github.com/bufbuild/connect-web/issues) and we’d be more than 
+happy to chat!
+
+
+## A small example
+
+Curious what this looks like in practice? From a [Protobuf schema](https://github.com/bufbuild/connect-web/blob/main/packages/example/eliza.proto), 
+we generate a small piece of RPC metadata with [@bufbuild/protoc-gen-connect-web](https://www.npmjs.com/package/@bufbuild/protoc-gen-connect-web), 
+the `ElizaService`. Using that metadata, we can build a server:
+
+```ts
+// server.ts
+import { createHandler, mergeHandlers } from "@bufbuild/connect-node";
+import { ElizaService } from "./gen/eliza_connectweb.js";
+import * as http2 from "http2";
+
+// A Node.js request listener that implements rpc Say(SayRequest) returns (SayResponse)
+const handleSay = createHandler(
+  ElizaService,
+  ElizaService.methods.say,
+  async (req) => {
+    return {
+      sentence: `you said: ${req.sentence}`,
+    };
+  }
+);
+
+http2.createServer(
+  mergeHandlers([handleSay]) // responds with 404 for other requests
+).listen(8080);
+```
+
+With that server running, you can make requests with any gRPC or Connect client.
+
+`buf curl` with the gRPC protocol:
+
+```bash
+buf curl --schema /Users/ts/buf/connect-web-main/packages/example/eliza.proto \
+  --protocol grpc --http2-prior-knowledge \
+  -d '{"sentence": "I feel happy."}' \
+  http://localhost:8080/buf.connect.demo.eliza.v1.ElizaService/Say
+```
+
+`curl` with the Connect protocol:
+
+```bash
+curl \
+    --header "Content-Type: application/json" \
+    --data '{"sentence": "I feel happy."}' \
+     --http2-prior-knowledge \
+    http://localhost:8080/buf.connect.demo.eliza.v1.ElizaService/Say
+```
+
+`@bufbuild/connect-node` with the gRPC protocol:
+
+```ts
+import { createHandler, mergeHandlers } from "@bufbuild/connect-node";
+import { ElizaService } from "./gen/eliza_connectweb.js";
+
+const transport = createGrpcTransport({
+  baseUrl: "http://localhost:8080",
+  httpVersion: "2",
+});
+
+const client = createPromiseClient(ElizaService, transport);
+const { sentence } = await client.say({ sentence: "I feel happy." });
+console.log(sentence) // you said: I feel happy.
+```
+
+A client for the web browser actually looks identical to this example - it would 
+simply use `createConnectTransport` from `@bufbuild/connect-web` instead.
+
+
+## Getting started
+
+To get started, head over to the [docs](https://connect.build/docs/node/getting-started) 
+for a tutorial, or take a look at [our example](https://github.com/bufbuild/connect-web/tree/main/packages/example). 


### PR DESCRIPTION
This adds:
- packages/connect-node/README.md
- packages/connect-core/README.md

And updates:
- README.md with a section "Connect for Node.js (Preview)" and a link to connect-query