### PR TITLE
Emit unpadded base64 for binary headers

### DIFF
--- a/packages/connect-core/src/http-headers.spec.ts
+++ b/packages/connect-core/src/http-headers.spec.ts
@@ -29,12 +29,12 @@ describe("encodeBinaryHeader()", function () {
   it("accepts unicode string", () => {
     const input = "👋";
     const encoded = encodeBinaryHeader(input);
-    expect(encoded).toEqual("8J+Riw==");
+    expect(encoded).toEqual("8J+Riw");
   });
   it("accepts Uint8Array", () => {
     const input = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
     const encoded = encodeBinaryHeader(input);
-    expect(encoded).toEqual("3q2+7w==");
+    expect(encoded).toEqual("3q2+7w");
   });
   it("accepts message", () => {
     const input = new M({
@@ -48,8 +48,13 @@ describe("encodeBinaryHeader()", function () {
 });
 
 describe("decodeBinaryHeader()", function () {
-  it("decodes Uint8Array", () => {
+  it("decodes Uint8Array with padding", () => {
     const decoded = decodeBinaryHeader("3q2+7w==");
+    expect(decoded).toBeInstanceOf(Uint8Array);
+    expect(decoded).toEqual(new Uint8Array([0xde, 0xad, 0xbe, 0xef]));
+  });
+  it("decodes Uint8Array without padding", () => {
+    const decoded = decodeBinaryHeader("3q2+7w");
     expect(decoded).toBeInstanceOf(Uint8Array);
     expect(decoded).toEqual(new Uint8Array([0xde, 0xad, 0xbe, 0xef]));
   });

--- a/packages/connect-core/src/http-headers.ts
+++ b/packages/connect-core/src/http-headers.ts
@@ -23,8 +23,8 @@ import { Code } from "./code.js";
  *
  * This function accepts raw binary data from a buffer, a string
  * with UTF-8 text, or a protobuf message. It encodes the input
- * with base64 and returns a string that can be used for a header
- * whose name ends with `-bin`.
+ * with unpadded base64 and returns a string that can be used for
+ * a header whose name ends with `-bin`.
  */
 export function encodeBinaryHeader(
   value: Uint8Array | ArrayBufferLike | Message | string
@@ -37,7 +37,7 @@ export function encodeBinaryHeader(
   } else {
     bytes = value instanceof Uint8Array ? value : new Uint8Array(value);
   }
-  return protoBase64.enc(bytes);
+  return protoBase64.enc(bytes).replace(/=+$/, "");
 }
 
 /**

--- a/packages/connect-core/src/protocol-grpc/trailer-status.spec.ts
+++ b/packages/connect-core/src/protocol-grpc/trailer-status.spec.ts
@@ -60,7 +60,7 @@ describe("setTrailerStatus()", function () {
     expect(t.get("grpc-status")).toBe("8"); // resource_exhausted
     expect(t.get("grpc-message")).toBe("soir%C3%A9e%20%F0%9F%8E%89");
     expect(t.get("grpc-status-details-bin")).toBe(
-      "CAgSDHNvaXLDqWUg8J+OiRo0Ci50eXBlLmdvb2dsZWFwaXMuY29tL2dvb2dsZS5wcm90b2J1Zi5JbnQzMlZhbHVlEgIIew=="
+      "CAgSDHNvaXLDqWUg8J+OiRo0Ci50eXBlLmdvb2dsZWFwaXMuY29tL2dvb2dsZS5wcm90b2J1Zi5JbnQzMlZhbHVlEgIIew"
     );
   });
 });

--- a/packages/connect-web-test/src/legacy-http-headers.spec.ts
+++ b/packages/connect-web-test/src/legacy-http-headers.spec.ts
@@ -28,12 +28,12 @@ describe("encodeBinaryHeader()", function () {
   it("accepts unicode string", () => {
     const input = "👋";
     const encoded = encodeBinaryHeader(input);
-    expect(encoded).toEqual("8J+Riw==");
+    expect(encoded).toEqual("8J+Riw");
   });
   it("accepts Uint8Array", () => {
     const input = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
     const encoded = encodeBinaryHeader(input);
-    expect(encoded).toEqual("3q2+7w==");
+    expect(encoded).toEqual("3q2+7w");
   });
   it("accepts message", () => {
     const input = new M({

--- a/packages/connect-web/src/http-headers.ts
+++ b/packages/connect-web/src/http-headers.ts
@@ -23,8 +23,8 @@ import { Code } from "./code.js";
  *
  * This function accepts raw binary data from a buffer, a string
  * with UTF-8 text, or a protobuf message. It encodes the input
- * with base64 and returns a string that can be used for a header
- * whose name ends with `-bin`.
+ * with unpadded base64 and returns a string that can be used for
+ * a header whose name ends with `-bin`.
  */
 export function encodeBinaryHeader(
   value: Uint8Array | ArrayBufferLike | Message | string
@@ -37,7 +37,7 @@ export function encodeBinaryHeader(
   } else {
     bytes = value instanceof Uint8Array ? value : new Uint8Array(value);
   }
-  return protoBase64.enc(bytes);
+  return protoBase64.enc(bytes).replace(/=+$/, "");
 }
 
 /**


### PR DESCRIPTION
The Connect protocol [asks](https://connect.build/docs/protocol/#:~:text=Binary%20headers%20must%20use%20keys%20ending%20in%20%22-bin%22%2C%20and%20implementations%20should%20emit%20unpadded%20base64-encoded%20values.%20Implementations%20must%20accept%20both%20padded%20and%20unpadded%20values):

> Binary headers must use keys ending in "-bin", and _implementations should emit unpadded base64-encoded values_. Implementations must accept both padded and unpadded values. 

This updates `encodeBinaryHeader()` to emit unpadded base64-encoded values.