### PR TITLE
Remove Node.js specific jsonParse() function

### DIFF
--- a/packages/connect-core/src/protocol-connect/error-json.ts
+++ b/packages/connect-core/src/protocol-connect/error-json.ts
@@ -76,6 +76,23 @@ export function errorFromJson(
 }
 
 /**
+ * Parse a Connect error from a serialized JSON value.
+ * Will return a ConnectError, but throw one in case the JSON is malformed.
+ */
+export function errorFromJsonBytes(
+  bytes: Uint8Array,
+  metadata?: HeadersInit
+): ConnectError {
+  let jsonValue: JsonValue;
+  try {
+    jsonValue = JSON.parse(new TextDecoder().decode(bytes)) as JsonValue;
+  } catch (e) {
+    throw newParseError(e, "", false);
+  }
+  return errorFromJson(jsonValue, metadata);
+}
+
+/**
  * Serialize the given error to JSON.
  *
  * The JSON serialization options are required to produce the optional

--- a/packages/connect-core/src/protocol-connect/index.ts
+++ b/packages/connect-core/src/protocol-connect/index.ts
@@ -24,7 +24,12 @@ export {
   endStreamFlag,
   createEndStreamSerialization,
 } from "./end-stream.js";
-export { errorFromJson, errorToJson, errorToJsonBytes } from "./error-json.js";
+export {
+  errorFromJson,
+  errorFromJsonBytes,
+  errorToJson,
+  errorToJsonBytes,
+} from "./error-json.js";
 export {
   parseContentType,
   contentTypeUnaryProto,

--- a/packages/connect-node/src/connect-transport.ts
+++ b/packages/connect-node/src/connect-transport.ts
@@ -43,7 +43,7 @@ import {
   createEndStreamSerialization,
   createRequestHeaderWithCompression,
   endStreamFlag,
-  errorFromJson,
+  errorFromJsonBytes,
   headerUnaryContentLength,
   headerUnaryEncoding,
   trailerDemux,
@@ -60,7 +60,6 @@ import type {
   PartialMessage,
   ServiceType,
 } from "@bufbuild/protobuf";
-import { jsonParse } from "./private/io.js";
 import {
   NodeHttp1TransportOptions,
   NodeHttp2TransportOptions,
@@ -205,8 +204,8 @@ export function createConnectTransport(
             );
           }
           if (isConnectUnaryError) {
-            throw errorFromJson(
-              jsonParse(responseBody),
+            throw errorFromJsonBytes(
+              responseBody,
               appendHeaders(header, trailer)
             );
           }

--- a/packages/connect-node/src/private/io.ts
+++ b/packages/connect-node/src/private/io.ts
@@ -13,17 +13,6 @@
 // limitations under the License.
 
 import type * as stream from "stream";
-import type { JsonValue } from "@bufbuild/protobuf";
-
-/**
- * TODO(TCN-1067) remove
- * @deprecated
- */
-export function jsonParse(bytes: Uint8Array): JsonValue {
-  const buf = bytes instanceof Buffer ? bytes : Buffer.from(bytes);
-  const jsonString = buf.toString("utf8");
-  return JSON.parse(jsonString) as JsonValue;
-}
 
 /**
  * TODO(TCN-1067) remove


### PR DESCRIPTION
The only place left where we still use the function is when parsing Connect unary errors.
This PR adds a dedicated function for this case: `errorFromJsonBytes()`.