### PR TITLE
Extend universal handlers to support compression middleware

### DIFF
--- a/packages/connect-node/src/compression.ts
+++ b/packages/connect-node/src/compression.ts
@@ -38,7 +38,7 @@ export const compressionGzip: Compression = {
 };
 
 export const compressionBrotli: Compression = {
-  name: "brotli",
+  name: "br",
   compress(bytes) {
     return brotliCompress(bytes, {});
   },

--- a/packages/connect-node/src/connect-handler.ts
+++ b/packages/connect-node/src/connect-handler.ts
@@ -252,7 +252,10 @@ function createStreamHandler<I extends Message<I>, O extends Message<O>>(
   serialization: MethodSerializationLookup<I, O>,
   endStreamSerialization: Serialization<EndStreamResponse>
 ) {
-  return function handle(req: UniversalServerRequest): UniversalServerResponse {
+  // eslint-disable-next-line @typescript-eslint/require-await
+  return async function handle(
+    req: UniversalServerRequest
+  ): Promise<UniversalServerResponse> {
     assertByteStreamRequest(req);
     const type = parseContentType(req.header.get(headerContentType));
     if (type == undefined || !type.stream) {

--- a/packages/connect-node/src/grpc-handler.ts
+++ b/packages/connect-node/src/grpc-handler.ts
@@ -97,7 +97,10 @@ function createHandler<I extends Message<I>, O extends Message<O>>(
     opt.jsonOptions,
     opt
   );
-  return function handle(req: UniversalServerRequest): UniversalServerResponse {
+  // eslint-disable-next-line @typescript-eslint/require-await
+  return async function handle(
+    req: UniversalServerRequest
+  ): Promise<UniversalServerResponse> {
     assertByteStreamRequest(req);
     const type = parseContentType(req.header.get(headerContentType));
     if (type == undefined) {

--- a/packages/connect-node/src/grpc-web-handler.ts
+++ b/packages/connect-node/src/grpc-web-handler.ts
@@ -104,7 +104,10 @@ function createHandler<I extends Message<I>, O extends Message<O>>(
     opt.jsonOptions,
     opt
   );
-  return function handle(req: UniversalServerRequest): UniversalServerResponse {
+  // eslint-disable-next-line @typescript-eslint/require-await
+  return async function handle(
+    req: UniversalServerRequest
+  ): Promise<UniversalServerResponse> {
     assertByteStreamRequest(req);
     const type = parseContentType(req.header.get(headerContentType));
     if (type == undefined || type.text) {

--- a/packages/connect-node/src/private/node-error.ts
+++ b/packages/connect-node/src/private/node-error.ts
@@ -50,8 +50,9 @@ export function connectErrorFromNodeReason(reason: unknown): ConnectError {
   } else if (
     chain.some(
       (p) =>
-        p.syscall === "getaddrinfo" &&
-        (p.code == "ENOTFOUND" || p.code == "EAI_AGAIN")
+        p.code == "ENOTFOUND" ||
+        p.code == "EAI_AGAIN" ||
+        p.code == "ECONNREFUSED"
     )
   ) {
     // Calling an unresolvable host should raise a ConnectError with

--- a/packages/connect-node/src/private/universal.ts
+++ b/packages/connect-node/src/private/universal.ts
@@ -47,7 +47,7 @@ export interface UniversalClientResponse {
  */
 export type UniversalHandlerFn = (
   request: UniversalServerRequest
-) => UniversalServerResponse | Promise<UniversalServerResponse>;
+) => Promise<UniversalServerResponse>;
 
 /**
  * A minimal abstraction of an HTTP request on the server side.
@@ -55,6 +55,7 @@ export type UniversalHandlerFn = (
 export interface UniversalServerRequest {
   httpVersion: string;
   method: string;
+  url: URL;
   header: Headers;
   /**
    * Many server frameworks parse request bodies with the mime type


### PR DESCRIPTION
This updates the bridge to Node.js for support of the npm package `compression`.

Other changes:
- makes the request URL available in universal server requests
- simplifies `UniversalHandlerFn` to only return promises
- treats the Node.js error ECONNREFUSED as Code.Unavailable
- implements routing based on request path in the universal layer